### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability via unsafe URL schemes in link shortener API

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-23 - Prevent Malicious URL Schemes in Link Shortener
+**Vulnerability:** The link shortening API allowed shortening of non-HTTP(S) URLs like `javascript:` and `data:` schemes, leading to Stored XSS.
+**Learning:** Even if frontend forms (like WTForms) use URL validators, the API layer must independently strictly validate the URL scheme (allowlisting `http` and `https`) to prevent malicious payloads from bypassing the UI.
+**Prevention:** Always enforce a strict scheme allowlist (`['http', 'https']`) on user-provided URLs at the backend/API level before accepting and storing them as redirects.

--- a/app/utils.py
+++ b/app/utils.py
@@ -123,6 +123,14 @@ def cleanup_phishing_urls():
 
 def is_safe_url(target_url):
     """Checks if the URL is not in the blocked domains list."""
+    # 0. Check URL scheme
+    try:
+        parsed = urlparse(target_url)
+        if parsed.scheme.lower() not in ['http', 'https']:
+            return False
+    except ValueError:
+        return False
+
     # 1. Check manual overrides from ENV
     blocked_env = os.environ.get('BLOCKED_DOMAINS', '').split(',')
     domain = ""


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `/api/v1/shorten` API endpoint and `is_safe_url` utility function allowed the shortening of non-HTTP(S) URLs, such as `javascript:` and `data:` schemes. This allowed an attacker to create short links pointing to malicious payloads.
🎯 **Impact:** When a user visits the shortened link, they would be redirected to the malicious scheme, leading to Stored Cross-Site Scripting (XSS).
🔧 **Fix:** Updated `is_safe_url` in `app/utils.py` to parse the URL and enforce a strict allowlist of schemes (`http` and `https`), rejecting any other scheme or malformed URLs.
✅ **Verification:** Verified by passing malicious URLs via the Python `test_xss_advanced.py` and the `/api/v1/shorten` endpoint, confirming they are now rejected with a 403 Forbidden response. All existing tests pass successfully. Also added a journal entry in `.jules/sentinel.md` documenting this finding.

---
*PR created automatically by Jules for task [11630180522601496138](https://jules.google.com/task/11630180522601496138) started by @arumes31*