### PR TITLE
[FIX] Unused Import `generate_qr`

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,11 +1,10 @@
 from flask import Blueprint, request, jsonify, current_app
 from werkzeug.security import generate_password_hash
 from app.models import db, URL, User
-from app.utils import generate_short_code, generate_qr, is_safe_url
+from app.utils import generate_short_code, is_safe_url
 from app import limiter, csrf
 from app.routes import shortened_links_total # Import the custom counter
 import datetime
-import base64
 
 api = Blueprint('api', __name__, url_prefix='/api/v1')
 csrf.exempt(api)

--- a/code_review_diff.patch
+++ b/code_review_diff.patch
@@ -1,0 +1,17 @@
+diff --git a/app/api.py b/app/api.py
+index 47af6a7..32ae6c3 100644
+--- a/app/api.py
++++ b/app/api.py
+@@ -1,11 +1,10 @@
+ from flask import Blueprint, request, jsonify, current_app
+ from werkzeug.security import generate_password_hash
+ from app.models import db, URL, User
+-from app.utils import generate_short_code, generate_qr, is_safe_url
++from app.utils import generate_short_code, is_safe_url
+ from app import limiter, csrf
+ from app.routes import shortened_links_total # Import the custom counter
+ import datetime
+-import base64
+
+ api = Blueprint('api', __name__, url_prefix='/api/v1')
+ csrf.exempt(api)


### PR DESCRIPTION
Removed unused imports `generate_qr` and `base64` from `app/api.py` to clean up the namespace and improve readability. Verified that the code compiles and existing tests pass (one pre-existing failure was unrelated).

---
*PR created automatically by Jules for task [10220309326948918407](https://jules.google.com/task/10220309326948918407) started by @arumes31*