### PR TITLE
[FIX] Unused Import `send_from_directory`

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,11 +1,9 @@
 import io
 import csv
-import json
 import datetime
 import uuid
-from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, send_file, current_app, session, jsonify, send_from_directory
+from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, send_file, current_app, session, jsonify
 from flask_login import login_user, logout_user, current_user, login_required
-from flask_limiter import Limiter
 from app import limiter, metrics # Import metrics
 from werkzeug.security import generate_password_hash, check_password_hash
 from PIL import Image


### PR DESCRIPTION
This PR removes the unused import `send_from_directory` from `app/routes.py` as identified in the issue. During the process, I also found and removed other unused imports (`flask_limiter.Limiter` and `json`) to further clean up the codebase. Removing unused imports improves code readability and maintains a clean namespace.

Verification:
- Performed syntax check using `python3 -m py_compile`.
- Ran existing test suite (unrelated pre-existing failure confirmed).
- Manually verified that the removed members are not used in the file.

---
*PR created automatically by Jules for task [1755906368499310061](https://jules.google.com/task/1755906368499310061) started by @arumes31*