### PR TITLE
[TEST] Missing tests for URL shortcode conflict resolution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,6 @@ def runner(app):
 
 @pytest.fixture
 def test_user(app):
-    # Returning a detached user object might still cause DetachedInstanceError.
-    # We'll return it and the tests will use its attributes.
     with app.app_context():
         user = User(
             username='testuser',
@@ -44,5 +42,8 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
-        db.session.expunge(user) # Detach it so it can be used outside
+        # Access attributes to load them before expunging
+        _ = user.id
+        _ = user.api_key
+        db.session.expunge(user)
         return user

--- a/tests/test_api_conflicts.py
+++ b/tests/test_api_conflicts.py
@@ -1,0 +1,45 @@
+import pytest
+from unittest.mock import patch
+from app.models import db, URL
+
+
+def test_custom_code_conflict(app, client, test_user):
+    """Test that a 409 error is returned when a custom code is already taken."""
+    # First, create a URL with a custom code
+    with app.app_context():
+        url = URL(short_code='TAKEN', long_url='https://example.com', user_id=test_user.id)
+        db.session.add(url)
+        db.session.commit()
+
+    # Now attempt to shorten another URL using the same custom code
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://another.com',
+                               'custom_code': 'taken'  # Case-insensitive check in app/api.py
+                           })
+
+    assert response.status_code == 409
+    assert response.get_json()['error'] == 'Custom code already taken'
+
+def test_autogen_code_collision(app, client, test_user):
+    """Test that the app retries generation when an auto-generated code collides."""
+    # First, create a URL with a known short code
+    with app.app_context():
+        url = URL(short_code='COLLIDE', long_url='https://example.com', user_id=test_user.id)
+        db.session.add(url)
+        db.session.commit()
+
+    # Mock generate_short_code to return 'COLLIDE' first, then 'SUCCESS'
+    with patch('app.api.generate_short_code') as mock_gen:
+        mock_gen.side_effect = ['COLLIDE', 'SUCCESS']
+
+        response = client.post('/api/v1/shorten',
+                               headers={'X-API-KEY': 'test-api-key'},
+                               json={'long_url': 'https://target.com'})
+
+        assert response.status_code == 201
+        data = response.get_json()
+        assert data['short_code'] == 'SUCCESS'
+        # Ensure it was called twice
+        assert mock_gen.call_count == 2


### PR DESCRIPTION
This PR adds missing tests for URL shortcode conflict resolution in the API. It covers both custom shortcode conflicts (returning 409) and auto-generated shortcode collisions (ensuring retry logic works). Additionally, it fixes a `DetachedInstanceError` in `tests/conftest.py` by pre-loading user attributes before expunging the object from the session.

---
*PR created automatically by Jules for task [13934768105478011260](https://jules.google.com/task/13934768105478011260) started by @arumes31*