### PR TITLE
[TEST] Missing tests for date parsing in API shorten

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
-        db.session.expunge(user) # Detach it so it can be used outside
+        db.session.refresh(user)
+        db.session.expunge(user)
         return user

--- a/tests/test_api_shorten_dates.py
+++ b/tests/test_api_shorten_dates.py
@@ -1,0 +1,89 @@
+import pytest
+from app.models import db, URL
+import datetime
+
+def test_api_shorten_start_at_valid(client, test_user):
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://example.com',
+                               'start_at': '2023-12-01T12:00:00'
+                           })
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['start_at'] == '2023-12-01T12:00:00'
+
+def test_api_shorten_start_at_z_suffix(client, test_user):
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://example.com',
+                               'start_at': '2023-12-01T12:00:00Z'
+                           })
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['start_at'] == '2023-12-01T12:00:00+00:00'
+
+def test_api_shorten_start_at_invalid(client, test_user):
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://example.com',
+                               'start_at': 'invalid-date'
+                           })
+    assert response.status_code == 400
+    assert response.get_json()['error'] == 'Invalid start_at format. Use ISO 8601'
+
+def test_api_shorten_end_at_valid(client, test_user):
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://example.com',
+                               'end_at': '2023-12-31T23:59:59'
+                           })
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['end_at'] == '2023-12-31T23:59:59'
+
+def test_api_shorten_end_at_z_suffix(client, test_user):
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://example.com',
+                               'end_at': '2023-12-31T23:59:59Z'
+                           })
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['end_at'] == '2023-12-31T23:59:59+00:00'
+
+def test_api_shorten_end_at_invalid(client, test_user):
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://example.com',
+                               'end_at': 'not-a-date'
+                           })
+    assert response.status_code == 400
+    assert response.get_json()['error'] == 'Invalid end_at format. Use ISO 8601'
+
+def test_api_shorten_dates_saved(app, client, test_user):
+    start_str = '2024-01-01T00:00:00Z'
+    end_str = '2024-12-31T23:59:59Z'
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://example.com',
+                               'start_at': start_str,
+                               'end_at': end_str
+                           })
+    assert response.status_code == 201
+    data = response.get_json()
+    short_code = data['short_code']
+
+    with app.app_context():
+        url = URL.query.filter_by(short_code=short_code).first()
+        assert url is not None
+        assert url.start_at is not None
+        assert url.end_at is not None
+        assert url.start_at.year == 2024
+        assert url.end_at.year == 2024


### PR DESCRIPTION
Added comprehensive tests for the `start_at` and `end_at` date parsing logic in the `/api/v1/shorten` endpoint. 

Changes:
- Created `tests/test_api_shorten_dates.py` with tests for:
    - Valid ISO 8601 date strings.
    - Date strings with the 'Z' suffix (e.g., UTC).
    - Invalid date strings for both `start_at` and `end_at` (ensuring 400 Bad Request is returned).
- Fixed a `DetachedInstanceError` in `tests/conftest.py` where the `test_user` fixture was returning a detached object without its attributes being loaded, causing failures in existing tests.

---
*PR created automatically by Jules for task [7175573389472872935](https://jules.google.com/task/7175573389472872935) started by @arumes31*