### PR TITLE
[FIX] Unused Import base64

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -5,7 +5,6 @@ from app.utils import generate_short_code, generate_qr, is_safe_url
 from app import limiter, csrf
 from app.routes import shortened_links_total # Import the custom counter
 import datetime
-import base64
 
 api = Blueprint('api', __name__, url_prefix='/api/v1')
 csrf.exempt(api)


### PR DESCRIPTION
Removed the unused `base64` import from `app/api.py`. This cleanup improves code readability and follows best practices by removing unnecessary dependencies from the namespace.

---
*PR created automatically by Jules for task [11222872154208680267](https://jules.google.com/task/11222872154208680267) started by @arumes31*