### PR TITLE
[FIX] Unused Import `Limiter`

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -5,7 +5,6 @@ import datetime
 import uuid
 from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, send_file, current_app, session, jsonify, send_from_directory
 from flask_login import login_user, logout_user, current_user, login_required
-from flask_limiter import Limiter
 from app import limiter, metrics # Import metrics
 from werkzeug.security import generate_password_hash, check_password_hash
 from PIL import Image


### PR DESCRIPTION
This PR removes an unused import of the `Limiter` class in `app/routes.py`. The codebase uses the `limiter` instance initialized in the app factory, so the direct class import is redundant. Removing it cleans up the namespace and improves code quality.

Verification:
- Ran `python3 -m py_compile app/routes.py` to ensure no syntax errors.
- Ran existing tests; one unrelated failure was confirmed to be present before the change.

---
*PR created automatically by Jules for task [2401648256152783937](https://jules.google.com/task/2401648256152783937) started by @arumes31*