### PR TITLE
[TEST] Untested API url get info endpoint

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -142,7 +142,7 @@ def get_url_info(short_code):
     return jsonify({
         'short_code': url_entry.short_code,
         'long_url': url_entry.long_url,
-        'clicks': url_entry.clicks,
+        'clicks': url_entry.clicks_count,
         'created_at': url_entry.created_at.isoformat(),
         'expires_at': url_entry.expires_at.isoformat() if url_entry.expires_at else None,
         'active': url_entry.is_active()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,7 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        # Ensure ID is loaded before expunging to avoid DetachedInstanceError
+        _ = user.id
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -57,3 +57,9 @@ def test_api_get_info_auth_invalid(client):
     response = client.get('/api/v1/TESTCODE',
                           headers={'X-API-KEY': 'invalid-key'})
     assert response.status_code == 401
+
+def test_api_get_info_not_found(client, test_user):
+    response = client.get('/api/v1/NONEXISTENT',
+                          headers={'X-API-KEY': 'test-api-key'})
+    assert response.status_code == 404
+    assert response.get_json()['error'] == 'URL not found'


### PR DESCRIPTION
This PR addresses the untested API url get info endpoint by adding comprehensive integration tests.

### Changes:
- **`app/api.py`**: Fixed a bug where `url_entry.clicks` (a SQLAlchemy relationship) was being returned instead of `url_entry.clicks_count` (an integer), which caused `TypeError: Object of type Click is not JSON serializable`.
- **`tests/conftest.py`**: Fixed a `DetachedInstanceError` by ensuring the `user.id` attribute is loaded before the user object is expunged from the session in the `test_user` fixture.
- **`tests/test_api_auth.py`**: Added a new test case for the 404 "URL not found" scenario and verified that the existing auth tests and success scenario pass correctly.

All 10 tests in `tests/test_api_auth.py` are now passing.

---
*PR created automatically by Jules for task [7323905342938648607](https://jules.google.com/task/7323905342938648607) started by @arumes31*