### PR TITLE
🧹 [FIX] High Cyclomatic Complexity in `get_geo_info`

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -224,55 +224,72 @@ def get_client_country(request):
             return cf_country
     return None
 
-def get_geo_info(ip, request=None):
-    """Fetches country from IP using local MaxMind database or Cloudflare header with Redis cache."""
+def _is_local_ip(ip):
+    """Checks if an IP address is a local/private address."""
+    return ip == '127.0.0.1' or ip.startswith('192.168.') or ip.startswith('10.') or ip.startswith('172.')
+
+def _get_cached_geo(ip):
+    """Fetches geo info from Redis cache if available."""
     global _redis_client
     if _redis_client is None:
         _redis_client = _get_redis_client()
 
-    # 1. Check Redis Cache
     if _redis_client:
         try:
-            cached_val = _redis_client.get(f"{_GEO_PREFIX}{ip}")
-            if cached_val:
-                return cached_val
+            return _redis_client.get(f"{_GEO_PREFIX}{ip}")
         except Exception:
-            pass # Fallback to lookup on Redis error
+            pass
+    return None
 
-    # 2. Check Cloudflare
-    if request:
-        cf_country = get_client_country(request)
-        if cf_country:
-            # Update Cache if Redis is available
-            if _redis_client:
-                try:
-                    _redis_client.setex(f"{_GEO_PREFIX}{ip}", _GEO_CACHE_TTL, cf_country)
-                except Exception:
-                    pass
-            return cf_country
+def _cache_geo_info(ip, country):
+    """Updates the Redis cache with geo info."""
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = _get_redis_client()
 
-    if ip == '127.0.0.1' or ip.startswith('192.168.') or ip.startswith('10.') or ip.startswith('172.'):
-        return "Local Network"
-    
-    # 3. Check Local DB
-    db_path = current_app.config.get('GEOIP_DB_PATH')
-    if not db_path or not os.path.exists(db_path):
-        return "Unknown (DB Missing)"
-
-    country = "Unknown"
-    try:
-        with geoip2.database.Reader(db_path) as reader:
-            response = reader.country(ip)
-            country = response.country.name or "Unknown"
-    except Exception: # nosec B110
-        pass
-    
-    # 4. Update Redis Cache
     if _redis_client:
         try:
             _redis_client.setex(f"{_GEO_PREFIX}{ip}", _GEO_CACHE_TTL, country)
         except Exception:
             pass
+
+def _get_local_db_geo(ip):
+    """Fetches country from local MaxMind database."""
+    db_path = current_app.config.get('GEOIP_DB_PATH')
+    if not db_path or not os.path.exists(db_path):
+        return "Unknown (DB Missing)"
+
+    try:
+        with geoip2.database.Reader(db_path) as reader:
+            response = reader.country(ip)
+            return response.country.name or "Unknown"
+    except Exception: # nosec B110
+        return "Unknown"
+
+def get_geo_info(ip, request=None):
+    """Fetches country from IP using local MaxMind database or Cloudflare header with Redis cache."""
+    # 1. Check Redis Cache
+    cached_val = _get_cached_geo(ip)
+    if cached_val:
+        return cached_val
+
+    # 2. Check Cloudflare
+    if request:
+        cf_country = get_client_country(request)
+        if cf_country:
+            _cache_geo_info(ip, cf_country)
+            return cf_country
+
+    # 3. Check Local Network
+    if _is_local_ip(ip):
+        return "Local Network"
+    
+    # 4. Check Local DB
+    country = _get_local_db_geo(ip)
+
+    # 5. Update Redis Cache
+    if country != "Unknown (DB Missing)":
+        _cache_geo_info(ip, country)
 
     return country
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,6 @@ def runner(app):
 
 @pytest.fixture
 def test_user(app):
-    # Returning a detached user object might still cause DetachedInstanceError.
-    # We'll return it and the tests will use its attributes.
     with app.app_context():
         user = User(
             username='testuser',
@@ -44,5 +42,8 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
-        db.session.expunge(user) # Detach it so it can be used outside
+        # Refresh to load attributes from DB
+        db.session.refresh(user)
+        # Detach it so it can be used outside
+        db.session.expunge(user)
         return user

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -39,8 +39,9 @@ def test_api_shorten_auth_invalid(client):
 
 def test_api_get_info_auth_success(app, client, test_user):
     # Create a URL first
+    user_id = test_user.id
     with app.app_context():
-        url = URL(short_code='TESTCODE', long_url='https://google.com', user_id=test_user.id)
+        url = URL(short_code='TESTCODE', long_url='https://google.com', user_id=user_id)
         db.session.add(url)
         db.session.commit()
 

--- a/tests/test_utils_geo.py
+++ b/tests/test_utils_geo.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from app.utils import get_geo_info
+
+def test_get_geo_info_cache_hit(app):
+    with patch('app.utils._redis_client') as mock_redis:
+        mock_redis.get.return_value = 'CachedCountry'
+        result = get_geo_info('1.2.3.4')
+        assert result == 'CachedCountry'
+        mock_redis.get.assert_called_with('geo:1.2.3.4')
+
+def test_get_geo_info_cloudflare_hit(app):
+    with patch('app.utils._redis_client') as mock_redis,          patch('app.utils.get_client_country') as mock_cf:
+        mock_redis.get.return_value = None
+        mock_cf.return_value = 'CFCountry'
+
+        request = MagicMock()
+        result = get_geo_info('1.2.3.4', request=request)
+
+        assert result == 'CFCountry'
+        mock_cf.assert_called_with(request)
+        mock_redis.setex.assert_called()
+
+def test_get_geo_info_local_network(app):
+    with patch('app.utils._redis_client') as mock_redis:
+        mock_redis.get.return_value = None
+
+        assert get_geo_info('127.0.0.1') == 'Local Network'
+        assert get_geo_info('192.168.1.1') == 'Local Network'
+        assert get_geo_info('10.0.0.1') == 'Local Network'
+        assert get_geo_info('172.16.0.1') == 'Local Network'
+
+def test_get_geo_info_db_lookup(app):
+    with patch('app.utils._redis_client') as mock_redis,          patch('geoip2.database.Reader') as mock_reader,          patch('os.path.exists') as mock_exists:
+
+        mock_redis.get.return_value = None
+        mock_exists.return_value = True
+
+        mock_instance = mock_reader.return_value.__enter__.return_value
+        mock_instance.country.return_value.country.name = 'DBCountry'
+
+        with app.app_context():
+            app.config['GEOIP_DB_PATH'] = '/fake/path.mmdb'
+            result = get_geo_info('8.8.8.8')
+
+        assert result == 'DBCountry'
+        mock_redis.setex.assert_called_with('geo:8.8.8.8', 300, 'DBCountry')
+
+def test_get_geo_info_db_missing(app):
+    with patch('app.utils._redis_client') as mock_redis,          patch('os.path.exists') as mock_exists:
+
+        mock_redis.get.return_value = None
+        mock_exists.return_value = False
+
+        with app.app_context():
+            app.config['GEOIP_DB_PATH'] = '/fake/path.mmdb'
+            result = get_geo_info('8.8.8.8')
+
+        assert result == 'Unknown (DB Missing)'


### PR DESCRIPTION
What: Refactored `get_geo_info` in `app/utils.py` by extracting logic into several private helper functions: `_is_local_ip`, `_get_cached_geo`, `_cache_geo_info`, and `_get_local_db_geo`.

Why: The original `get_geo_info` function had high cyclomatic complexity, making it difficult to maintain and test. Breaking it down into smaller, focused functions improves readability and allows for better unit testing of individual components.

Verification:
- Created a new test file `tests/test_utils_geo.py` covering all logical paths (cache hit, Cloudflare header, local network, DB lookup).
- Updated `tests/conftest.py` to fix `DetachedInstanceError` in tests.
- Ran all tests using `pytest`, ensuring 100% pass rate for relevant tests.
- Verified Python syntax using `py_compile`.

Result: Improved code health and maintainability of the GeoIP lookup logic.

---
*PR created automatically by Jules for task [13995682044482722031](https://jules.google.com/task/13995682044482722031) started by @arumes31*