### PR TITLE
[SECURITY] CSV Injection Vulnerability in Links Export

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The link shortening API allowed shortening of non-HTTP(S) URLs like `javascript:` and `data:` schemes, leading to Stored XSS.
 **Learning:** Even if frontend forms (like WTForms) use URL validators, the API layer must independently strictly validate the URL scheme (allowlisting `http` and `https`) to prevent malicious payloads from bypassing the UI.
 **Prevention:** Always enforce a strict scheme allowlist (`['http', 'https']`) on user-provided URLs at the backend/API level before accepting and storing them as redirects.
+## 2026-03-23 - CSV Injection in Links Export
+**Vulnerability:** User-controlled fields like `long_url` and `short_code` were exported to CSV without sanitization, allowing spreadsheet formula injection (e.g., payloads starting with `=`, `+`, `-`, or `@`).
+**Learning:** CSV exports containing user-generated content must sanitize cells that begin with formula-triggering characters. Prepending a single quote (`'`) is an effective way to force spreadsheet software to treat the cell content as literal text.
+**Prevention:** Implement a universal `sanitize_csv_field` helper and apply it to all user-influenced string fields in CSV generation logic.

--- a/app/routes.py
+++ b/app/routes.py
@@ -21,7 +21,7 @@ ratelimit_hits_total = Counter('redrx_ratelimit_hits_total', 'Total number of re
 
 from app.models import db, URL, User, Click
 from app.forms import ShortenURLForm, LoginForm, RegisterForm, LinkPasswordForm, EditURLForm
-from app.utils import generate_short_code, get_qr_data_url, generate_qr, select_rotate_target, get_geo_info, is_safe_url, get_client_ip, _get_redis_client, get_blocked_domains
+from app.utils import generate_short_code, get_qr_data_url, generate_qr, select_rotate_target, get_geo_info, is_safe_url, get_client_ip, _get_redis_client, get_blocked_domains, sanitize_csv_field
 
 main = Blueprint('main', __name__)
 
@@ -394,8 +394,8 @@ def export_links():
     
     for u in urls:
         writer.writerow([
-            u.short_code, 
-            u.long_url, 
+            sanitize_csv_field(u.short_code),
+            sanitize_csv_field(u.long_url),
             u.clicks_count, 
             u.created_at.isoformat(),
             u.last_accessed_at.isoformat() if u.last_accessed_at else 'Never',

--- a/app/utils.py
+++ b/app/utils.py
@@ -325,3 +325,16 @@ def get_qr_data_url(data, color='black', bg='white', logo_img=None):
     """Returns a base64 encoded data URL for the QR code."""
     img_buffer = generate_qr(data, color, bg, logo_img)
     return base64.b64encode(img_buffer.read()).decode()
+
+def sanitize_csv_field(value):
+    """
+    Escapes fields starting with =, +, -, or @ to prevent CSV injection.
+    Prepend a single quote ' if the value starts with one of these characters.
+    """
+    if value is None:
+        return ""
+
+    str_val = str(value)
+    if str_val and str_val[0] in ('=', '+', '-', '@'):
+        return "'" + str_val
+    return str_val

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,9 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        # Access attributes to ensure they are loaded before expunging
+        _ = user.id
+        _ = user.api_key
+        _ = user.username
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_csv_export.py
+++ b/tests/test_csv_export.py
@@ -1,0 +1,51 @@
+import pytest
+import io
+import csv
+from app.models import db, URL, User
+
+def test_export_links_csv_injection_mitigated(app, client):
+    # 1. Setup: Create a user and a malicious URL
+    with app.app_context():
+        user = User(
+            username='csvuser',
+            email='csv@example.com',
+            password_hash='pbkdf2:sha256:260000$8mX...dummy'
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        malicious_url = URL(
+            short_code='=DANGER',
+            long_url='=SUM(1+2)',
+            user_id=user.id
+        )
+        db.session.add(malicious_url)
+        db.session.commit()
+
+        user_id = user.id
+
+    # 2. Login the user
+    with client.session_transaction() as sess:
+        sess['_user_id'] = str(user_id)
+        sess['_fresh'] = True
+
+    # 3. Call export-links
+    response = client.get('/export-links')
+    assert response.status_code == 200
+    assert response.mimetype == 'text/csv'
+
+    # 4. Verify mitigation
+    data = response.data.decode('utf-8')
+    reader = csv.reader(io.StringIO(data))
+    rows = list(reader)
+
+    found_sanitized_long = False
+    found_sanitized_short = False
+    for row in rows:
+        if "'=SUM(1+2)" in row:
+            found_sanitized_long = True
+        if "'=DANGER" in row:
+            found_sanitized_short = True
+
+    assert found_sanitized_long, f"Long URL payload not sanitized: {rows}"
+    assert found_sanitized_short, f"Short code payload not sanitized: {rows}"


### PR DESCRIPTION
This PR addresses a CSV injection vulnerability in the links export functionality.

### Problem
The `/export-links` endpoint allowed users to export their shortened links to a CSV file. However, fields like `long_url` and `short_code` were exported without sanitization. If these fields contained spreadsheet formulas (e.g., starting with `=`, `+`, `-`, or `@`), they could be executed when the CSV was opened in software like Microsoft Excel or Google Sheets.

### Solution
I implemented a `sanitize_csv_field` helper function in `app/utils.py` that prepends a single quote (`'`) to any string starting with the dangerous characters. This forces spreadsheet applications to treat the content as literal text rather than a formula.

I then updated the `export_links` route in `app/routes.py` to apply this sanitization to the `short_code` and `long_url` columns.

### Verification
- Created a new test file `tests/test_csv_export.py` that specifically tests for CSV injection and verifies the mitigation.
- Fixed a pre-existing `DetachedInstanceError` in the test fixtures (`tests/conftest.py`) that was causing some authentication tests to fail.
- Ran the full suite of relevant tests, and all passed.
- Updated the security journal in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [476485785438108276](https://jules.google.com/task/476485785438108276) started by @arumes31*