### PR TITLE
[PERF] Loading All URLs into Memory for Cleanup

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,13 @@
 **Vulnerability:** The link shortening API allowed shortening of non-HTTP(S) URLs like `javascript:` and `data:` schemes, leading to Stored XSS.
 **Learning:** Even if frontend forms (like WTForms) use URL validators, the API layer must independently strictly validate the URL scheme (allowlisting `http` and `https`) to prevent malicious payloads from bypassing the UI.
 **Prevention:** Always enforce a strict scheme allowlist (`['http', 'https']`) on user-provided URLs at the backend/API level before accepting and storing them as redirects.
+
+## 2026-05-21 - Memory Efficiency in Large Database Iterations
+**Issue:** Iterating over all records using `.all()` in a long-running maintenance task (phishing URL cleanup) can lead to Out-Of-Memory (OOM) errors as the database grows.
+**Learning:** Use SQLAlchemy's `.yield_per()` to stream results from the database in chunks. To truly keep memory low, objects must be explicitly expunged from the session (`db.session.expunge(obj)`) after processing if they are not being modified/deleted, as SQLAlchemy's Identity Map otherwise keeps them all in memory.
+**Prevention:** Always use chunked iteration (`yield_per`) and active session management (expunging or session clearing) for operations involving large result sets.
+
+## 2026-05-21 - Fix DetachedInstanceError in Tests
+**Issue:** Test fixtures returning expunged objects caused `DetachedInstanceError` when tests tried to access attributes that weren't pre-loaded.
+**Learning:** When using `db.session.expunge(obj)` in a fixture, ensure all required attributes are accessed (loaded) within the session context before expunging, or avoid expunging if the session remains valid for the test duration.
+**Prevention:** Always pre-load required attributes before detaching objects from a SQLAlchemy session in test fixtures.

--- a/app/utils.py
+++ b/app/utils.py
@@ -87,14 +87,15 @@ def cleanup_phishing_urls():
         if not blocked_domains:
             return
 
-        urls = URL.query.all()
+        # Use yield_per to stream results and avoid OOM
+        urls = URL.query.yield_per(100)
         removed_count = 0
         
         for url_entry in urls:
-            # Check main long_url
+            is_phishing = False
             try:
+                # Check main long_url
                 domain = urlparse(url_entry.long_url).netloc.lower()
-                is_phishing = False
                 if domain:
                     parts = domain.split('.')
                     for i in range(len(parts)):
@@ -117,7 +118,14 @@ def cleanup_phishing_urls():
                 if is_phishing:
                     db.session.delete(url_entry)
                     removed_count += 1
-            except Exception: # nosec B112
+                else:
+                    # Expunge from session to save memory
+                    db.session.expunge(url_entry)
+            except Exception:
+                try:
+                    db.session.expunge(url_entry)
+                except Exception:
+                    pass
                 continue
         
         if removed_count > 0:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,6 @@ def runner(app):
 
 @pytest.fixture
 def test_user(app):
-    # Returning a detached user object might still cause DetachedInstanceError.
-    # We'll return it and the tests will use its attributes.
     with app.app_context():
         user = User(
             username='testuser',
@@ -44,5 +42,9 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
-        db.session.expunge(user) # Detach it so it can be used outside
+        # Access attributes to ensure they are loaded and don't require refresh
+        _ = user.id
+        _ = user.username
+        _ = user.api_key
+        db.session.expunge(user)
         return user

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,0 +1,36 @@
+import os
+import tempfile
+from app.models import db, URL
+from app.utils import cleanup_phishing_urls
+
+def test_cleanup_phishing_urls(app):
+    with app.app_context():
+        # Setup blocked domains file
+        fd, path = tempfile.mkstemp()
+        try:
+            with os.fdopen(fd, 'w') as tmp:
+                tmp.write("phishing.com\nbad-actor.org\n")
+
+            app.config['BLOCKED_DOMAINS_PATH'] = path
+            app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+
+            # Create some URLs
+            u1 = URL(short_code='safe', long_url='https://google.com')
+            u2 = URL(short_code='bad', long_url='https://phishing.com/login')
+            u3 = URL(short_code='rotate', long_url='https://safe.com')
+            u3.rotate_targets = ["https://bad-actor.org/hack"]
+
+            db.session.add_all([u1, u2, u3])
+            db.session.commit()
+
+            # Run cleanup
+            cleanup_phishing_urls()
+
+            # Verify
+            remaining = URL.query.all()
+            codes = [u.short_code for u in remaining]
+            assert 'safe' in codes
+            assert 'bad' not in codes
+            assert 'rotate' not in codes
+        finally:
+            os.remove(path)


### PR DESCRIPTION
This PR optimizes the `cleanup_phishing_urls` function to prevent Out-Of-Memory (OOM) issues when the database contains a large number of URLs.

Key changes:
- Switched from `URL.query.all()` to `URL.query.yield_per(100)` to stream records.
- Implemented active session management by expunging records from the SQLAlchemy session after processing.
- Fixed a `DetachedInstanceError` in the test suite fixtures.
- Added a new test file `tests/test_cleanup.py` to verify the cleanup logic.

---
*PR created automatically by Jules for task [13393891104301780043](https://jules.google.com/task/13393891104301780043) started by @arumes31*