### PR TITLE
🧹 [Refactor] Reduce cyclomatic complexity in redirect_to_url

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -181,8 +181,53 @@ def index():
     return render_template('index.html', form=form, 
                            short_url=short_url, qr_data=qr_data, stats_url=stats_url)
 
-@main.route('/<short_code>')
-@limiter.limit(lambda: current_app.config.get('RATELIMIT_REDIRECT', '100 per minute'))
+def _get_redirect_target(url_entry, user_agent, cached_domains):
+    """Determines the final destination URL based on device and rotation settings."""
+    target_url = url_entry.long_url
+    device_match = False
+
+    if url_entry.ios_target_url and (user_agent.os.family == "iOS"):
+        target_url = url_entry.ios_target_url
+        device_match = True
+    elif url_entry.android_target_url and (user_agent.os.family == "Android"):
+        target_url = url_entry.android_target_url
+        device_match = True
+
+    if not device_match and url_entry.rotate_targets:
+        safe_rotate_targets = [alt for alt in url_entry.rotate_targets if is_safe_url(alt, cached_domains)]
+        alt = select_rotate_target(safe_rotate_targets)
+        if alt:
+            target_url = alt
+
+    return target_url
+
+def _record_click_stats(url_entry, user_agent, client_ip, referrer):
+    """Records click statistics, including IP masking and geolocation."""
+    url_entry.clicks_count += 1
+
+    # Mask IP for privacy (e.g. 1.2.3.4 -> 1.2.x.x)
+    masked_ip = client_ip
+    parts = client_ip.split(".")
+    if len(parts) == 4:
+        masked_ip = f"{parts[0]}.{parts[1]}.x.x"
+    else: # IPv6 support
+        v6_parts = client_ip.split(":")
+        if len(v6_parts) >= 2:
+            masked_ip = f"{v6_parts[0]}:{v6_parts[1]}:x:x"
+
+    new_click = Click(
+        url_id=url_entry.id,
+        ip_address=masked_ip,
+        country=get_geo_info(client_ip, request),
+        browser=user_agent.browser.family,
+        platform=user_agent.os.family,
+        referrer=referrer or "Direct"
+    )
+    db.session.add(new_click)
+    db.session.commit()
+
+@main.route("/<short_code>")
+@limiter.limit(lambda: current_app.config.get("RATELIMIT_REDIRECT", "100 per minute"))
 def redirect_to_url(short_code):
     url_entry = URL.query.filter_by(short_code=short_code).first()
     
@@ -193,38 +238,15 @@ def redirect_to_url(short_code):
         abort(410)
         
     if url_entry.password_hash:
-        # Check session
         auth_key = f"auth_{short_code}"
         if not session.get(auth_key):
-             return redirect(url_for('main.link_password_auth', short_code=short_code))
+             return redirect(url_for("main.link_password_auth", short_code=short_code))
              
-    # Select destination
-    target_url = url_entry.long_url
-    
-    # Device Targeting (overrides main URL, but rotate logic is complex with this - let's keep it simple: Device > Rotate > Main)
-    # However, user might want to rotate AND target.
-    # Logic: 
-    # 1. Check Device specific URL
-    # 2. If no device match or no device URL, check Rotate
-    # 3. Else Main
-    
-    ua_string = request.headers.get('User-Agent')
+    ua_string = request.headers.get("User-Agent")
     user_agent = parse(ua_string)
-    
-    device_match = False
-    if url_entry.ios_target_url and (user_agent.os.family == 'iOS'):
-        target_url = url_entry.ios_target_url
-        device_match = True
-    elif url_entry.android_target_url and (user_agent.os.family == 'Android'):
-        target_url = url_entry.android_target_url
-        device_match = True
-
     cached_domains = get_blocked_domains()
-    if not device_match and url_entry.rotate_targets:
-        safe_rotate_targets = [alt for alt in url_entry.rotate_targets if is_safe_url(alt, cached_domains)]
-        alt = select_rotate_target(safe_rotate_targets)
-        if alt:
-            target_url = alt
+
+    target_url = _get_redirect_target(url_entry, user_agent, cached_domains)
             
     if not is_safe_url(target_url, cached_domains):
         abort(403)
@@ -233,43 +255,15 @@ def redirect_to_url(short_code):
     url_entry.last_accessed_at = datetime.datetime.now(datetime.timezone.utc)
     db.session.commit()
 
-    # Increment Prometheus Counter
     redirections_total.inc()
 
-    # Stats
     if url_entry.stats_enabled:
-        url_entry.clicks_count += 1
-        
-        # Record detailed click
-        # Note: We already parsed UA above, reuse it
-        client_ip = get_client_ip(request)
-        
-        # Mask IP for privacy (e.g. 1.2.3.4 -> 1.2.x.x)
-        masked_ip = client_ip
-        parts = client_ip.split('.')
-        if len(parts) == 4:
-            masked_ip = f"{parts[0]}.{parts[1]}.x.x"
-        else: # IPv6 support
-            v6_parts = client_ip.split(':')
-            if len(v6_parts) >= 2:
-                masked_ip = f"{v6_parts[0]}:{v6_parts[1]}:x:x"
-
-        new_click = Click(
-            url_id=url_entry.id,
-            ip_address=masked_ip,
-            country=get_geo_info(client_ip, request),
-            browser=user_agent.browser.family,
-            platform=user_agent.os.family,
-            referrer=request.referrer or "Direct"
-        )
-        db.session.add(new_click)
-        db.session.commit()
+        _record_click_stats(url_entry, user_agent, get_client_ip(request), request.referrer)
     
-    # If preview mode is enabled
     if url_entry.preview_mode:
-        return render_template('preview.html', target_url=target_url, short_code=short_code)
+        return render_template("preview.html", target_url=target_url, short_code=short_code)
 
-    return render_template('redirect.html', target_url=target_url)
+    return render_template("redirect.html", target_url=target_url)
 
 @main.route('/link-auth/<short_code>', methods=['GET', 'POST'])
 @limiter.limit("10 per minute")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_redirect.py
+++ b/tests/test_redirect.py
@@ -1,0 +1,64 @@
+import pytest
+from app.models import URL, db
+import datetime
+
+def test_redirect_basic(client, app):
+    with app.app_context():
+        url = URL(short_code='test', long_url='http://example.com')
+        db.session.add(url)
+        db.session.commit()
+
+    response = client.get('/test')
+    assert response.status_code == 200
+    assert b'http://example.com' in response.data
+
+def test_redirect_404(client):
+    response = client.get('/nonexistent')
+    assert response.status_code == 404
+
+def test_redirect_inactive(client, app):
+    with app.app_context():
+        # Expired URL
+        url = URL(short_code='expired', long_url='http://example.com',
+                  expires_at=datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1))
+        db.session.add(url)
+        db.session.commit()
+
+    response = client.get('/expired')
+    assert response.status_code == 410
+
+def test_redirect_password(client, app):
+    with app.app_context():
+        from werkzeug.security import generate_password_hash
+        url = URL(short_code='protected', long_url='http://example.com',
+                  password_hash=generate_password_hash('password'))
+        db.session.add(url)
+        db.session.commit()
+
+    # Should redirect to password auth page
+    response = client.get('/protected')
+    assert response.status_code == 302
+    assert '/link-auth/protected' in response.location
+
+def test_redirect_ios(client, app):
+    with app.app_context():
+        url = URL(short_code='ios', long_url='http://example.com',
+                  ios_target_url='http://apple.com')
+        db.session.add(url)
+        db.session.commit()
+
+    headers = {'User-Agent': 'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1'}
+    response = client.get('/ios', headers=headers)
+    assert response.status_code == 200
+    assert b'http://apple.com' in response.data
+
+def test_redirect_rotation(client, app):
+    with app.app_context():
+        url = URL(short_code='rotate', long_url='http://example.com',
+                  rotate_targets=['http://alt1.com', 'http://alt2.com'])
+        db.session.add(url)
+        db.session.commit()
+
+    response = client.get('/rotate')
+    assert response.status_code == 200
+    assert any(b in response.data for b in [b'http://alt1.com', b'http://alt2.com'])


### PR DESCRIPTION
What:
- Extracted redirection target selection logic into `_get_redirect_target`.
- Extracted click statistics recording logic into `_record_click_stats`.
- Cleaned up `redirect_to_url` to use these helpers.
- Fixed a `DetachedInstanceError` in `tests/conftest.py` by refreshing the user object before expunging it.
- Added comprehensive tests for redirections in `tests/test_redirect.py`.

Why:
- High cyclomatic complexity in `redirect_to_url` made it difficult to maintain and test.
- The refactoring improves readability and follows the Single Responsibility Principle.

Verification:
- Syntax verified with `py_compile`.
- Full test suite passed: `PYTHONPATH=. python3 -m pytest tests/`.
- New tests in `tests/test_redirect.py` cover basic redirection, 404/410 cases, password protection, device targeting, and rotation.

Result:
- Reduced complexity in `redirect_to_url`.
- Improved test coverage and reliability of the test suite.

---
*PR created automatically by Jules for task [349781663263828450](https://jules.google.com/task/349781663263828450) started by @arumes31*