### PR TITLE
[TEST] Missing tests for API token validation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,6 @@ def runner(app):
 
 @pytest.fixture
 def test_user(app):
-    # Returning a detached user object might still cause DetachedInstanceError.
-    # We'll return it and the tests will use its attributes.
     with app.app_context():
         user = User(
             username='testuser',
@@ -44,5 +42,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
-        db.session.expunge(user) # Detach it so it can be used outside
+        db.session.refresh(user) # Load all attributes before expunging
+        db.session.expunge(user)
         return user

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -57,3 +57,30 @@ def test_api_get_info_auth_invalid(client):
     response = client.get('/api/v1/TESTCODE',
                           headers={'X-API-KEY': 'invalid-key'})
     assert response.status_code == 401
+
+def test_get_user_from_api_key_empty_string(app, test_user):
+    with app.test_request_context(headers={'X-API-KEY': ''}):
+        user = get_user_from_api_key()
+        assert user is None
+
+def test_get_user_from_api_key_whitespace(app, test_user):
+    with app.test_request_context(headers={'X-API-KEY': '   '}):
+        user = get_user_from_api_key()
+        assert user is None
+
+def test_get_user_from_api_key_very_long(app, test_user):
+    with app.test_request_context(headers={'X-API-KEY': 'a' * 100}):
+        user = get_user_from_api_key()
+        assert user is None
+
+def test_api_shorten_auth_empty_key(client):
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': ''},
+                           json={'long_url': 'https://google.com'})
+    assert response.status_code == 401
+
+def test_api_shorten_auth_whitespace_key(client):
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': '   '},
+                           json={'long_url': 'https://google.com'})
+    assert response.status_code == 401


### PR DESCRIPTION
This PR addresses the missing tests for API token validation in the `app/api.py` file.

### What was fixed?
1.  **`tests/conftest.py`**: Updated the `test_user` fixture to call `db.session.refresh(user)` before `db.session.expunge(user)`. This ensures all database-populated fields (like `id`) are available in the detached object, preventing `DetachedInstanceError`.
2.  **`tests/test_api_auth.py`**: Added several edge case tests for the `get_user_from_api_key` function and its integration with API endpoints:
    -   Empty string API key (`""`)
    -   Whitespace API key (`"   "`)
    -   Exceedingly long API key (exceeding database column length)

### Why?
-   The `get_user_from_api_key` function lacked comprehensive coverage for invalid or edge-case inputs.
-   The `DetachedInstanceError` was causing legitimate tests (like `test_api_get_info_auth_success`) to fail, hindering further development and verification.

### Verification
-   Ran `python3 -m pytest tests/test_api_auth.py`
-   All 14 tests passed (9 existing + 5 new edge cases).
-   The `DetachedInstanceError` previously seen in `test_api_get_info_auth_success` is resolved.

---
*PR created automatically by Jules for task [10591529804054328576](https://jules.google.com/task/10591529804054328576) started by @arumes31*