### PR TITLE
🧹 [FIX] Unused Import `metrics`

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -5,8 +5,7 @@ import datetime
 import uuid
 from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, send_file, current_app, session, jsonify, send_from_directory
 from flask_login import login_user, logout_user, current_user, login_required
-from flask_limiter import Limiter
-from app import limiter, metrics # Import metrics
+from app import limiter
 from werkzeug.security import generate_password_hash, check_password_hash
 from PIL import Image
 from user_agents import parse


### PR DESCRIPTION
### What
Removed unused imports `metrics` (from `app`) and `Limiter` (from `flask_limiter`) in `app/routes.py`.

### Why
Removing unused imports cleans up the namespace and improves readability without breaking any functionality. The `limiter` object is used via decorators, but the `Limiter` class itself and the `metrics` object are not referenced in the file.

### Verification
- Ran `python3 -m py_compile app/routes.py` to ensure no syntax errors.
- Ran `PYTHONPATH=. python3 -m pytest` to verify no regressions.
- Confirmed that the one failing test (`tests/test_api_auth.py::test_api_get_info_auth_success`) is a pre-existing issue related to `DetachedInstanceError` and is unaffected by these changes.
- Manually checked for any other occurrences of `metrics` or `Limiter` in the file.


---
*PR created automatically by Jules for task [17913566368177126179](https://jules.google.com/task/17913566368177126179) started by @arumes31*