### PR TITLE
[FIX] Uncached Environment Variable Parsing in Frequently Called Function

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,11 @@
 **Vulnerability:** The link shortening API allowed shortening of non-HTTP(S) URLs like `javascript:` and `data:` schemes, leading to Stored XSS.
 **Learning:** Even if frontend forms (like WTForms) use URL validators, the API layer must independently strictly validate the URL scheme (allowlisting `http` and `https`) to prevent malicious payloads from bypassing the UI.
 **Prevention:** Always enforce a strict scheme allowlist (`['http', 'https']`) on user-provided URLs at the backend/API level before accepting and storing them as redirects.
+## 2026-05-26 - Optimize Environment Variable Parsing in High-Frequency Security Functions
+**Issue:** Parsing environment variables (like ) inside high-frequency utility functions (like ) caused redundant string processing and  calls.
+**Learning:** Cache configuration values derived from environment variables at the module level or during app initialization to improve performance. For domain-based security checks, prefer suffix matching (e.g.,  loop with ) over simple substring matching () to avoid false positives and over-blocking.
+**Prevention:** Implement lazy caching for environment variable parsing in performance-critical code paths.
+## 2026-05-26 - Optimize Environment Variable Parsing in High-Frequency Security Functions
+**Issue:** Parsing environment variables (like BLOCKED_DOMAINS) inside high-frequency utility functions (like is_safe_url) caused redundant string processing and os.environ.get calls.
+**Learning:** Cache configuration values derived from environment variables at the module level or during app initialization to improve performance. For domain-based security checks, prefer suffix matching (e.g., while loop with find('.')) over simple substring matching (in) to avoid false positives and over-blocking.
+**Prevention:** Implement lazy caching for environment variable parsing in performance-critical code paths.

--- a/app/utils.py
+++ b/app/utils.py
@@ -34,6 +34,31 @@ _blocked_domains_cache = None
 _blocked_domains_mtime = 0
 _blocked_domains_path = None
 _blocked_domains_ino = 0
+_blocked_env_domains = None
+
+def _get_blocked_env_domains():
+    """Lazily parses and caches the BLOCKED_DOMAINS environment variable."""
+    global _blocked_env_domains
+    if _blocked_env_domains is None:
+        raw_env = os.environ.get("BLOCKED_DOMAINS", "")
+        _blocked_env_domains = {b.strip().lower() for b in raw_env.split(",") if b.strip()}
+    return _blocked_env_domains
+def _is_domain_blocked(domain, blocked_set):
+    """Checks if the domain or any of its parent domains are in the blocked set."""
+    if not domain or not blocked_set:
+        return False
+
+    check_domain = domain
+    while True:
+        if check_domain in blocked_set:
+            return True
+        dot_idx = check_domain.find(".")
+        if dot_idx == -1:
+            break
+        check_domain = check_domain[dot_idx + 1:]
+        if not check_domain:
+            break
+    return False
 
 def update_phishing_list():
     """Downloads the latest phishing domain lists."""
@@ -181,16 +206,15 @@ def is_safe_url(target_url, blocked_domains_cache=None):
         return False
 
     # 1. Check manual overrides from ENV
-    blocked_env = os.environ.get('BLOCKED_DOMAINS', '').split(',')
+    blocked_env = _get_blocked_env_domains()
     domain = ""
     try:
         domain = urlparse(target_url).netloc.lower()
         if not domain: # For relative or malformed URLs
              return False
              
-        for b in blocked_env:
-            if b.strip() and b.strip().lower() in domain:
-                return False
+        if _is_domain_blocked(domain, blocked_env):
+            return False
     except Exception:
         return False
 
@@ -200,12 +224,8 @@ def is_safe_url(target_url, blocked_domains_cache=None):
 
     blocked_domains = blocked_domains_cache if blocked_domains_cache is not None else get_blocked_domains()
     if blocked_domains:
-        parts = domain.split('.')
-        for i in range(len(parts)):
-            check_domain = '.'.join(parts[i:])
-            if check_domain in blocked_domains:
-                return False
-            
+        if _is_domain_blocked(domain, blocked_domains):
+            return False
     return True
 
 def get_client_ip(request):

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,6 +1,6 @@
 import pytest
 from app.api import get_user_from_api_key
-from app.models import db, URL
+from app.models import db, URL, User
 
 def test_get_user_from_api_key_valid(app, test_user):
     with app.test_request_context(headers={'X-API-KEY': 'test-api-key'}):
@@ -38,8 +38,12 @@ def test_api_shorten_auth_invalid(client):
     assert response.status_code == 401
 
 def test_api_get_info_auth_success(app, client, test_user):
-    # Create a URL first
+    # Fetch user in context
     with app.app_context():
+        # Ensure user exists in this session
+        db.session.add(test_user)
+        # Re-attach if it was detached
+        test_user = db.session.merge(test_user)
         url = URL(short_code='TESTCODE', long_url='https://google.com', user_id=test_user.id)
         db.session.add(url)
         db.session.commit()


### PR DESCRIPTION
This PR addresses a performance issue where the `BLOCKED_DOMAINS` environment variable was being parsed and split on every call to `is_safe_url`.

Changes:
- Added `_blocked_env_domains` global variable and `_get_blocked_env_domains()` helper to lazily cache the environment variable.
- Added `_is_domain_blocked()` helper to perform efficient domain suffix matching using a while loop and `.find('.')`, avoiding redundant `split` and `join` operations. This also fixes a bug where simple substring matching was used, potentially causing false positives.
- Updated `is_safe_url` to use these helpers for both the environment variable check and the phishing list check.
- Fixed a `DetachedInstanceError` in `tests/test_api_auth.py` by ensuring the test user is correctly merged into the session.
- Documented the fix and security learnings in `.jules/sentinel.md`.

Verification:
- Created and ran a temporary test script `tests/test_is_safe_url.py` which verified that:
  - `os.environ.get` is called only once for `BLOCKED_DOMAINS`.
  - Suffix matching works correctly (e.g., `evil.com` blocks `sub.evil.com` but not `notevil.com`).
- Ran the full test suite (`pytest`), all tests passed.

---
*PR created automatically by Jules for task [9518676339835766251](https://jules.google.com/task/9518676339835766251) started by @arumes31*