### PR TITLE
🧹 [FIX] Unused Import `TextAreaField`

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileField, FileAllowed
-from wtforms import StringField, PasswordField, BooleanField, IntegerField, DateField, TimeField, TextAreaField, SubmitField
+from wtforms import StringField, PasswordField, BooleanField, IntegerField, DateField, TimeField, SubmitField
 from wtforms.validators import DataRequired, URL, Optional, Length, Email, NumberRange
 
 class ShortenURLForm(FlaskForm):


### PR DESCRIPTION
The `TextAreaField` import in `app/forms.py` was unused. Removing it cleans up the namespace and improves readability.

Verification:
- Syntax check: `python3 -m py_compile app/forms.py` passed.
- Test suite: `PYTHONPATH=. pytest tests/` ran. 8/9 tests passed. The failure in `test_api_get_info_auth_success` is pre-existing and unrelated to these changes.

---
*PR created automatically by Jules for task [4700879953241589502](https://jules.google.com/task/4700879953241589502) started by @arumes31*