### PR TITLE
[SECURITY] Enforce static SECRET_KEY in production

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The link shortening API allowed shortening of non-HTTP(S) URLs like `javascript:` and `data:` schemes, leading to Stored XSS.
 **Learning:** Even if frontend forms (like WTForms) use URL validators, the API layer must independently strictly validate the URL scheme (allowlisting `http` and `https`) to prevent malicious payloads from bypassing the UI.
 **Prevention:** Always enforce a strict scheme allowlist (`['http', 'https']`) on user-provided URLs at the backend/API level before accepting and storing them as redirects.
+
+## 2026-03-23 - Enforce Static Secret Keys in Production
+**Vulnerability:** Use of `os.urandom(24)` as a fallback for `SECRET_KEY` caused session invalidation on every app restart and allowed insecure silent fallbacks if the environment variable was missing.
+**Learning:** Production applications should never silently fall back to dynamic or weak secrets. Enforce the presence of a cryptographically secure, static `SECRET_KEY` via environment variables and fail-fast (e.g., raise `RuntimeError`) during configuration loading if it is missing.
+**Prevention:** In the configuration class, check for the required secret and raise an exception if it's missing while not in debug mode. Provide a clear error message for operators.

--- a/config.py
+++ b/config.py
@@ -1,7 +1,19 @@
 import os
 
 class Config:
-    SECRET_KEY = os.environ.get('SECRET_KEY') or os.urandom(24)
+    # Security: Enforce static SECRET_KEY in production
+    SECRET_KEY = os.environ.get('SECRET_KEY')
+    DEBUG = os.environ.get('FLASK_DEBUG', 'false').lower() in ['true', '1', 't']
+
+    if not SECRET_KEY:
+        if DEBUG:
+            # Fallback for development only
+            SECRET_KEY = 'dev-secret-key-do-not-use-in-production'
+        else:
+            # Fail fast in production if SECRET_KEY is missing
+            raise RuntimeError("SECRET_KEY environment variable is required in production. "
+                             "For security, the application will not start without it.")
+
     basedir = os.path.abspath(os.path.dirname(__file__))
     SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
         'sqlite:///' + os.path.join(basedir, 'db', 'shortener.db')
@@ -27,5 +39,3 @@ class Config:
     ANONYMIZE_LOGS = os.environ.get('ANONYMIZE_LOGS', 'false').lower() in ['true', '1', 't']
     ENABLE_SEO = os.environ.get('ENABLE_SEO', 'false').lower() in ['true', '1', 't']
     SEO_DOMAIN = os.environ.get('SEO_DOMAIN', 'redrx.eu')
-    DEBUG = os.environ.get('FLASK_DEBUG', 'false').lower() in ['true', '1', 't']
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,58 @@
+import pytest
+import os
+from unittest.mock import patch
+from config import Config
+
+def test_config_production_missing_secret_key():
+    # Simulate production environment without SECRET_KEY
+    env_vars = {
+        'FLASK_DEBUG': 'false',
+        'SECRET_KEY': ''
+    }
+    with patch.dict(os.environ, env_vars, clear=True):
+        # Reloading Config might be tricky if it's already imported,
+        # but let's see if we can just re-instantiate or if the logic runs on import.
+        # The logic is currently at the class level, so it runs on import/definition.
+        # We might need to use importlib to reload the module.
+        import importlib
+        import config
+        with pytest.raises(RuntimeError) as excinfo:
+            importlib.reload(config)
+        assert "SECRET_KEY environment variable is required in production" in str(excinfo.value)
+
+def test_config_production_with_secret_key():
+    # Simulate production environment with SECRET_KEY
+    env_vars = {
+        'FLASK_DEBUG': 'false',
+        'SECRET_KEY': 'super-secret-production-key'
+    }
+    with patch.dict(os.environ, env_vars, clear=True):
+        import importlib
+        import config
+        reloaded_config = importlib.reload(config)
+        assert reloaded_config.Config.SECRET_KEY == 'super-secret-production-key'
+
+def test_config_development_missing_secret_key():
+    # Simulate development environment without SECRET_KEY
+    env_vars = {
+        'FLASK_DEBUG': 'true',
+        'SECRET_KEY': ''
+    }
+    with patch.dict(os.environ, env_vars, clear=True):
+        import importlib
+        import config
+        reloaded_config = importlib.reload(config)
+        assert reloaded_config.Config.SECRET_KEY == 'dev-secret-key-do-not-use-in-production'
+        assert reloaded_config.Config.DEBUG is True
+
+def test_config_development_with_secret_key():
+    # Simulate development environment with SECRET_KEY
+    env_vars = {
+        'FLASK_DEBUG': 'true',
+        'SECRET_KEY': 'dev-override-key'
+    }
+    with patch.dict(os.environ, env_vars, clear=True):
+        import importlib
+        import config
+        reloaded_config = importlib.reload(config)
+        assert reloaded_config.Config.SECRET_KEY == 'dev-override-key'


### PR DESCRIPTION
This PR addresses the security vulnerability where the application would silently fall back to a dynamic secret key (os.urandom) if the SECRET_KEY environment variable was missing.

Changes:
- Modified `config.py` to enforce `SECRET_KEY` in production.
- Added a `RuntimeError` if `SECRET_KEY` is missing and `FLASK_DEBUG` is false.
- Set a static development key in debug mode to prevent session invalidation on restart.
- Fixed a `DetachedInstanceError` in `tests/conftest.py` by adding `db.session.refresh(user)` before expunging.
- Added a new test file `tests/test_config.py` to verify configuration behavior.
- Updated `.jules/sentinel.md` with the new security learning.

---
*PR created automatically by Jules for task [11451328647190476465](https://jules.google.com/task/11451328647190476465) started by @arumes31*