### PR TITLE
[FIX] Unused Import `TextAreaField`

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileField, FileAllowed
-from wtforms import StringField, PasswordField, BooleanField, IntegerField, DateField, TimeField, TextAreaField, SubmitField
+from wtforms import StringField, PasswordField, BooleanField, IntegerField, DateField, TimeField, SubmitField
 from wtforms.validators import DataRequired, URL, Optional, Length, Email, NumberRange
 
 class ShortenURLForm(FlaskForm):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user


### PR DESCRIPTION
This PR removes an unused import `TextAreaField` from `app/forms.py` to improve code cleanliness. Additionally, it fixes a `DetachedInstanceError` in `tests/conftest.py` by ensuring the user object is refreshed before being expunged from the session, which was discovered while running the test suite.

---
*PR created automatically by Jules for task [12549667219274067555](https://jules.google.com/task/12549667219274067555) started by @arumes31*