### PR TITLE
[TEST] Missing tests for date parsing in API shorten

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_api_dates.py
+++ b/tests/test_api_dates.py
@@ -1,0 +1,78 @@
+import pytest
+import datetime
+from app.models import db, URL
+
+def test_api_shorten_valid_start_at(client, test_user):
+    # ISO 8601 format
+    start_date = "2025-01-01T12:00:00"
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://google.com',
+                               'start_at': start_date
+                           })
+    assert response.status_code == 201
+    data = response.get_json()
+
+    # Check DB
+    url = db.session.get(URL, URL.query.filter_by(short_code=data['short_code']).first().id)
+    assert url.start_at is not None
+    assert url.start_at == datetime.datetime.fromisoformat(start_date)
+
+def test_api_shorten_valid_start_at_z_suffix(client, test_user):
+    # ISO 8601 format with Z suffix
+    start_date_str = "2025-01-01T12:00:00Z"
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://google.com',
+                               'start_at': start_date_str
+                           })
+    assert response.status_code == 201
+    data = response.get_json()
+
+    # Check DB
+    url = db.session.get(URL, URL.query.filter_by(short_code=data['short_code']).first().id)
+    assert url.start_at is not None
+    # fromisoformat with +00:00 should match what we expect
+    expected = datetime.datetime.fromisoformat(start_date_str.replace('Z', '+00:00'))
+    # Note: Depending on how SQLAlchemy/SQLite handles timezones, we might need to be careful with naive vs aware datetimes.
+    # The code uses fromisoformat which might return aware if +00:00 is present.
+    assert url.start_at.replace(tzinfo=None) == expected.replace(tzinfo=None)
+
+def test_api_shorten_valid_end_at(client, test_user):
+    # ISO 8601 format
+    end_date = "2025-12-31T23:59:59"
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://google.com',
+                               'end_at': end_date
+                           })
+    assert response.status_code == 201
+    data = response.get_json()
+
+    # Check DB
+    url = db.session.get(URL, URL.query.filter_by(short_code=data['short_code']).first().id)
+    assert url.end_at is not None
+    assert url.end_at == datetime.datetime.fromisoformat(end_date)
+
+def test_api_shorten_invalid_start_at(client, test_user):
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://google.com',
+                               'start_at': 'invalid-date'
+                           })
+    assert response.status_code == 400
+    assert response.get_json()['error'] == 'Invalid start_at format. Use ISO 8601'
+
+def test_api_shorten_invalid_end_at(client, test_user):
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://google.com',
+                               'end_at': 'not-a-date'
+                           })
+    assert response.status_code == 400
+    assert response.get_json()['error'] == 'Invalid end_at format. Use ISO 8601'


### PR DESCRIPTION
This PR adds missing tests for the date parsing logic in the API's `/shorten` endpoint. 

Specifically, it:
1.  Creates a new test file `tests/test_api_dates.py` to cover:
    - Valid ISO 8601 date parsing for `start_at` and `end_at`.
    - Handling of the 'Z' (UTC) suffix in date strings.
    - Error handling for invalid date formats (returns 400 Bad Request).
2.  Fixes a `DetachedInstanceError` in `tests/conftest.py` by adding `db.session.refresh(user)` before expunging the user from the session, ensuring that all attributes are loaded and accessible in tests.

Verification:
- All 5 new tests in `tests/test_api_dates.py` pass.
- All 9 existing tests in `tests/test_api_auth.py` pass (after the `conftest.py` fix).

---
*PR created automatically by Jules for task [13106003386868410917](https://jules.google.com/task/13106003386868410917) started by @arumes31*