### PR TITLE
[TEST] Missing tests for API token validation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -57,3 +57,18 @@ def test_api_get_info_auth_invalid(client):
     response = client.get('/api/v1/TESTCODE',
                           headers={'X-API-KEY': 'invalid-key'})
     assert response.status_code == 401
+
+def test_get_user_from_api_key_empty(app, test_user):
+    with app.test_request_context(headers={'X-API-KEY': ''}):
+        user = get_user_from_api_key()
+        assert user is None
+
+def test_get_user_from_api_key_whitespace(app, test_user):
+    with app.test_request_context(headers={'X-API-KEY': '   '}):
+        user = get_user_from_api_key()
+        assert user is None
+
+def test_get_user_from_api_key_extremely_long(app, test_user):
+    with app.test_request_context(headers={'X-API-KEY': 'a' * 1000}):
+        user = get_user_from_api_key()
+        assert user is None


### PR DESCRIPTION
The task was to add missing tests for API token validation in `app/api.py`.

Specifically:
1.  **Fixed Test Infrastructure**: Modified `tests/conftest.py` to add `db.session.refresh(user)` before `db.session.expunge(user)` in the `test_user` fixture. This prevents `sqlalchemy.orm.exc.DetachedInstanceError` when accessing user attributes (like `user.id`) in tests.
2.  **Added Comprehensive Tests**: Expanded `tests/test_api_auth.py` with three new test cases for `get_user_from_api_key`:
    *   `test_get_user_from_api_key_empty`: Verifies that an empty string API key returns `None`.
    *   `test_get_user_from_api_key_whitespace`: Verifies that a whitespace-only API key returns `None`.
    *   `test_get_user_from_api_key_extremely_long`: Verifies that an extremely long API key (1000 characters) returns `None`, ensuring it doesn't cause database or logic errors.

All 12 tests in the suite now pass successfully.

---
*PR created automatically by Jules for task [11024509230142534368](https://jules.google.com/task/11024509230142534368) started by @arumes31*