### PR TITLE
[FIX] High Cyclomatic Complexity in `get_geo_info`

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -14,6 +14,11 @@ import os
 from urllib.parse import urlparse
 import redis
 
+# Import geo helpers
+from app.utils_geo import (
+    _get_cached_geo, _set_cached_geo, _is_local_ip, _get_local_db_geo
+)
+
 # Redis cache configuration for GeoIP lookups
 _REDIS_URL = os.environ.get('RATELIMIT_STORAGE_URL', 'redis://localhost:6379')
 _GEO_CACHE_TTL = 300  # 5 minutes
@@ -48,7 +53,6 @@ def update_phishing_list():
         return
     
     try:
-        # Check if file is old (e.g. older than interval hours)
         if os.path.exists(path):
             file_age = time.time() - os.path.getmtime(path)
             if file_age < (interval * 3600):
@@ -231,48 +235,26 @@ def get_geo_info(ip, request=None):
         _redis_client = _get_redis_client()
 
     # 1. Check Redis Cache
-    if _redis_client:
-        try:
-            cached_val = _redis_client.get(f"{_GEO_PREFIX}{ip}")
-            if cached_val:
-                return cached_val
-        except Exception:
-            pass # Fallback to lookup on Redis error
+    cached_val = _get_cached_geo(ip, _redis_client)
+    if cached_val:
+        return cached_val
 
     # 2. Check Cloudflare
     if request:
         cf_country = get_client_country(request)
         if cf_country:
-            # Update Cache if Redis is available
-            if _redis_client:
-                try:
-                    _redis_client.setex(f"{_GEO_PREFIX}{ip}", _GEO_CACHE_TTL, cf_country)
-                except Exception:
-                    pass
+            _set_cached_geo(ip, cf_country, _redis_client)
             return cf_country
 
-    if ip == '127.0.0.1' or ip.startswith('192.168.') or ip.startswith('10.') or ip.startswith('172.'):
+    # 3. Check Local Network
+    if _is_local_ip(ip):
         return "Local Network"
-    
-    # 3. Check Local DB
-    db_path = current_app.config.get('GEOIP_DB_PATH')
-    if not db_path or not os.path.exists(db_path):
-        return "Unknown (DB Missing)"
 
-    country = "Unknown"
-    try:
-        with geoip2.database.Reader(db_path) as reader:
-            response = reader.country(ip)
-            country = response.country.name or "Unknown"
-    except Exception: # nosec B110
-        pass
-    
-    # 4. Update Redis Cache
-    if _redis_client:
-        try:
-            _redis_client.setex(f"{_GEO_PREFIX}{ip}", _GEO_CACHE_TTL, country)
-        except Exception:
-            pass
+    # 4. Check Local DB
+    country = _get_local_db_geo(ip)
+
+    # 5. Update Redis Cache
+    _set_cached_geo(ip, country, _redis_client)
 
     return country
 

--- a/app/utils_geo.py
+++ b/app/utils_geo.py
@@ -1,0 +1,40 @@
+import os
+import geoip2.database
+from flask import current_app
+
+_GEO_PREFIX = "geo:"
+_GEO_CACHE_TTL = 300  # 5 minutes
+
+def _get_cached_geo(ip, redis_client):
+    """Retrieves geo info from Redis cache."""
+    if redis_client:
+        try:
+            return redis_client.get(f"{_GEO_PREFIX}{ip}")
+        except Exception:
+            pass
+    return None
+
+def _set_cached_geo(ip, country, redis_client):
+    """Sets geo info in Redis cache."""
+    if redis_client:
+        try:
+            redis_client.setex(f"{_GEO_PREFIX}{ip}", _GEO_CACHE_TTL, country)
+        except Exception:
+            pass
+
+def _is_local_ip(ip):
+    """Checks if the IP is a local network address."""
+    return ip == "127.0.0.1" or ip.startswith("192.168.") or ip.startswith("10.") or ip.startswith("172.")
+
+def _get_local_db_geo(ip):
+    """Fetches country from local MaxMind database."""
+    db_path = current_app.config.get("GEOIP_DB_PATH")
+    if not db_path or not os.path.exists(db_path):
+        return "Unknown (DB Missing)"
+
+    try:
+        with geoip2.database.Reader(db_path) as reader:
+            response = reader.country(ip)
+            return response.country.name or "Unknown"
+    except Exception:
+        return "Unknown"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_geo_info.py
+++ b/tests/test_geo_info.py
@@ -1,0 +1,65 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from flask import Flask
+from app.utils import get_geo_info
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config['GEOIP_DB_PATH'] = '/path/to/db'
+    return app
+
+@pytest.fixture
+def mock_redis():
+    with patch('app.utils._redis_client') as mock_r:
+        yield mock_r
+
+def test_get_geo_info_cached(app, mock_redis):
+    with app.app_context():
+        mock_redis.get.return_value = "CachedCountry"
+        result = get_geo_info("1.2.3.4")
+        assert result == "CachedCountry"
+        mock_redis.get.assert_called_with("geo:1.2.3.4")
+
+def test_get_geo_info_cloudflare(app, mock_redis):
+    with app.app_context():
+        mock_redis.get.return_value = None
+        mock_request = MagicMock()
+
+        with patch('app.utils.get_client_country') as mock_get_cf:
+            mock_get_cf.return_value = "CFCountry"
+            result = get_geo_info("1.2.3.4", request=mock_request)
+
+        assert result == "CFCountry"
+        mock_redis.setex.assert_called_with("geo:1.2.3.4", 300, "CFCountry")
+
+def test_get_geo_info_local_network(app, mock_redis):
+    with app.app_context():
+        mock_redis.get.return_value = None
+        assert get_geo_info("127.0.0.1") == "Local Network"
+        assert get_geo_info("192.168.1.1") == "Local Network"
+        assert get_geo_info("10.0.0.1") == "Local Network"
+        assert get_geo_info("172.16.0.1") == "Local Network"
+
+def test_get_geo_info_local_db(app, mock_redis):
+    with app.app_context():
+        mock_redis.get.return_value = None
+
+        with patch('os.path.exists') as mock_exists,              patch('geoip2.database.Reader') as mock_reader:
+            mock_exists.return_value = True
+            mock_response = MagicMock()
+            mock_response.country.name = "LocalDBCountry"
+            mock_reader.return_value.__enter__.return_value.country.return_value = mock_response
+
+            result = get_geo_info("8.8.8.8")
+
+        assert result == "LocalDBCountry"
+        mock_redis.setex.assert_called_with("geo:8.8.8.8", 300, "LocalDBCountry")
+
+def test_get_geo_info_db_missing(app, mock_redis):
+    with app.app_context():
+        mock_redis.get.return_value = None
+        with patch('os.path.exists') as mock_exists:
+            mock_exists.return_value = False
+            result = get_geo_info("8.8.8.8")
+        assert result == "Unknown (DB Missing)"


### PR DESCRIPTION
This PR addresses the high cyclomatic complexity (score 19) in the `get_geo_info` function in `app/utils.py`.

### Changes:
- **Refactoring:** The logic for Redis caching, local network checks, and local database lookups was extracted into dedicated helper functions.
- **Modularity:** Created `app/utils_geo.py` to house the extracted helper functions, keeping `app/utils.py` focused.
- **Verification:** Reduced complexity score to 6 (Radon grade B).
- **Testing:** Added a new test suite `tests/test_geo_info.py` covering all logical paths of the refactored function.
- **Fix:** Resolved a pre-existing `DetachedInstanceError` in `tests/conftest.py` by adding `db.session.refresh(user)` before expunging the test user.

Verified with `radon cc` and the full test suite.

---
*PR created automatically by Jules for task [3209577817711260546](https://jules.google.com/task/3209577817711260546) started by @arumes31*