### PR TITLE
[FIX] Unused Import `send_from_directory`

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3,7 +3,7 @@ import csv
 import json
 import datetime
 import uuid
-from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, send_file, current_app, session, jsonify, send_from_directory
+from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, send_file, current_app, session, jsonify
 from flask_login import login_user, logout_user, current_user, login_required
 from flask_limiter import Limiter
 from app import limiter, metrics # Import metrics

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user


### PR DESCRIPTION
### What
Removed the unused `send_from_directory` import from `app/routes.py`.
Fixed a `DetachedInstanceError` in `tests/conftest.py` that was causing test failures.

### Why
Cleaning up unused imports improves code readability and maintainability.
Fixing the test suite ensures that verification of changes is reliable and that the codebase remains in a healthy state.

### Verification
- Ran `python3 -m py_compile app/routes.py` to check for syntax errors.
- Ran `PYTHONPATH=. python3 -m pytest` and confirmed all 9 tests passed.
- Verified the removal of the import using `grep`.

---
*PR created automatically by Jules for task [1425864569938711049](https://jules.google.com/task/1425864569938711049) started by @arumes31*