### PR TITLE
[FIX] Unused Import `Limiter`

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -5,7 +5,6 @@ import datetime
 import uuid
 from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, send_file, current_app, session, jsonify, send_from_directory
 from flask_login import login_user, logout_user, current_user, login_required
-from flask_limiter import Limiter
 from app import limiter, metrics # Import metrics
 from werkzeug.security import generate_password_hash, check_password_hash
 from PIL import Image


### PR DESCRIPTION
Removed the unused `Limiter` import from `app/routes.py` to clean up the namespace and improve readability. The file uses the pre-initialized `limiter` instance from the `app` package instead.

---
*PR created automatically by Jules for task [14396732368774457999](https://jules.google.com/task/14396732368774457999) started by @arumes31*