### PR TITLE
[SECURITY] Insecure Secret Key Generation Fallback

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,31 +1,68 @@
 import os
 
-class Config:
-    SECRET_KEY = os.environ.get('SECRET_KEY') or os.urandom(24)
-    basedir = os.path.abspath(os.path.dirname(__file__))
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
-        'sqlite:///' + os.path.join(basedir, 'db', 'shortener.db')
-    SQLALCHEMY_TRACK_MODIFICATIONS = False
-    MAX_CONTENT_LENGTH = 1 * 1024 * 1024 # 1MB Limit
-    
-    # App specific config
-    BASE_DOMAIN = os.environ.get('BASE_DOMAIN', 'short.example.com')
-    EXPIRY_HOURS = int(os.environ.get('EXPIRY_HOURS', 24))
-    SHORT_CODE_LENGTH = int(os.environ.get('SHORT_CODE_LENGTH', 6))
-    DEFAULT_QR_COLOR = os.environ.get('DEFAULT_QR_COLOR', 'black')
-    DEFAULT_QR_BG = os.environ.get('DEFAULT_QR_BACKGROUND', 'white')
-    GEOIP_DB_PATH = os.environ.get('GEOIP_DB_PATH', os.path.join(basedir, 'GeoLite2-Country.mmdb'))
-    PHISHING_LIST_URLS = os.environ.get('PHISHING_LIST_URLS', 'https://raw.githubusercontent.com/mitchellkrogza/Phishing.Database/master/phishing-domains-ACTIVE.txt').split(',')
-    BLOCKED_DOMAINS_PATH = os.environ.get('BLOCKED_DOMAINS_PATH', os.path.join(basedir, 'blocked_domains.txt'))
-    PHISHING_CHECK_INTERVAL = int(os.environ.get('PHISHING_CHECK_INTERVAL', 24))
-    ENABLE_PHISHING_CHECK = os.environ.get('ENABLE_PHISHING_CHECK', 'true').lower() in ['true', '1', 't']
-    ENABLE_AUTO_REMOVE_PHISHING = os.environ.get('ENABLE_AUTO_REMOVE_PHISHING', 'false').lower() in ['true', '1', 't']
-    PHISHING_REMOVE_INTERVAL = int(os.environ.get('PHISHING_REMOVE_INTERVAL', 24))
-    DISABLE_ANONYMOUS_CREATE = os.environ.get('DISABLE_ANONYMOUS_CREATE', 'false').lower() in ['true', '1', 't']
-    DISABLE_REGISTRATION = os.environ.get('DISABLE_REGISTRATION', 'false').lower() in ['true', '1', 't']
-    USE_CLOUDFLARE = os.environ.get('USE_CLOUDFLARE', 'false').lower() in ['true', '1', 't']
-    ANONYMIZE_LOGS = os.environ.get('ANONYMIZE_LOGS', 'false').lower() in ['true', '1', 't']
-    ENABLE_SEO = os.environ.get('ENABLE_SEO', 'false').lower() in ['true', '1', 't']
-    SEO_DOMAIN = os.environ.get('SEO_DOMAIN', 'redrx.eu')
-    DEBUG = os.environ.get('FLASK_DEBUG', 'false').lower() in ['true', '1', 't']
 
+class Config:
+    _flask_debug = os.environ.get("FLASK_DEBUG", "false").lower() in ["true", "1", "t"]
+    SECRET_KEY = os.environ.get("SECRET_KEY")
+    if not SECRET_KEY:
+        if _flask_debug:
+            SECRET_KEY = "dev-secret-key-do-not-use-in-production"
+        else:
+            raise RuntimeError(
+                "SECRET_KEY environment variable is not set and the app is not in debug mode."
+            )
+
+    basedir = os.path.abspath(os.path.dirname(__file__))
+    SQLALCHEMY_DATABASE_URI = os.environ.get(
+        "DATABASE_URL"
+    ) or "sqlite:///" + os.path.join(basedir, "db", "shortener.db")
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    MAX_CONTENT_LENGTH = 1 * 1024 * 1024  # 1MB Limit
+
+    # App specific config
+    BASE_DOMAIN = os.environ.get("BASE_DOMAIN", "short.example.com")
+    EXPIRY_HOURS = int(os.environ.get("EXPIRY_HOURS", 24))
+    SHORT_CODE_LENGTH = int(os.environ.get("SHORT_CODE_LENGTH", 6))
+    DEFAULT_QR_COLOR = os.environ.get("DEFAULT_QR_COLOR", "black")
+    DEFAULT_QR_BG = os.environ.get("DEFAULT_QR_BACKGROUND", "white")
+    GEOIP_DB_PATH = os.environ.get(
+        "GEOIP_DB_PATH", os.path.join(basedir, "GeoLite2-Country.mmdb")
+    )
+    PHISHING_LIST_URLS = os.environ.get(
+        "PHISHING_LIST_URLS",
+        "https://raw.githubusercontent.com/mitchellkrogza/Phishing.Database/master/phishing-domains-ACTIVE.txt",
+    ).split(",")
+    BLOCKED_DOMAINS_PATH = os.environ.get(
+        "BLOCKED_DOMAINS_PATH", os.path.join(basedir, "blocked_domains.txt")
+    )
+    PHISHING_CHECK_INTERVAL = int(os.environ.get("PHISHING_CHECK_INTERVAL", 24))
+    ENABLE_PHISHING_CHECK = os.environ.get("ENABLE_PHISHING_CHECK", "true").lower() in [
+        "true",
+        "1",
+        "t",
+    ]
+    ENABLE_AUTO_REMOVE_PHISHING = os.environ.get(
+        "ENABLE_AUTO_REMOVE_PHISHING", "false"
+    ).lower() in ["true", "1", "t"]
+    PHISHING_REMOVE_INTERVAL = int(os.environ.get("PHISHING_REMOVE_INTERVAL", 24))
+    DISABLE_ANONYMOUS_CREATE = os.environ.get(
+        "DISABLE_ANONYMOUS_CREATE", "false"
+    ).lower() in ["true", "1", "t"]
+    DISABLE_REGISTRATION = os.environ.get("DISABLE_REGISTRATION", "false").lower() in [
+        "true",
+        "1",
+        "t",
+    ]
+    USE_CLOUDFLARE = os.environ.get("USE_CLOUDFLARE", "false").lower() in [
+        "true",
+        "1",
+        "t",
+    ]
+    ANONYMIZE_LOGS = os.environ.get("ANONYMIZE_LOGS", "false").lower() in [
+        "true",
+        "1",
+        "t",
+    ]
+    ENABLE_SEO = os.environ.get("ENABLE_SEO", "false").lower() in ["true", "1", "t"]
+    SEO_DOMAIN = os.environ.get("SEO_DOMAIN", "redrx.eu")
+    DEBUG = _flask_debug

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,13 +5,15 @@ from app import create_app
 from app.models import db, User
 from config import Config
 
+
 class TestConfig(Config):
     TESTING = True
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    SQLALCHEMY_DATABASE_URI = "sqlite:///:memory:"
     WTF_CSRF_ENABLED = False
     ENABLE_PHISHING_CHECK = False
     # Use a real path in a temporary directory
-    GEOIP_DB_PATH = os.path.join(tempfile.gettempdir(), 'test_geoip.mmdb')
+    GEOIP_DB_PATH = os.path.join(tempfile.gettempdir(), "test_geoip.mmdb")
+
 
 @pytest.fixture
 def app():
@@ -23,26 +25,28 @@ def app():
         db.session.remove()
         db.drop_all()
 
+
 @pytest.fixture
 def client(app):
     return app.test_client()
+
 
 @pytest.fixture
 def runner(app):
     return app.test_cli_runner()
 
+
 @pytest.fixture
 def test_user(app):
-    # Returning a detached user object might still cause DetachedInstanceError.
-    # We'll return it and the tests will use its attributes.
     with app.app_context():
         user = User(
-            username='testuser',
-            email='test@example.com',
-            password_hash='pbkdf2:sha256:...', # dummy hash
-            api_key='test-api-key'
+            username="testuser",
+            email="test@example.com",
+            password_hash="pbkdf2:sha256:...",  # dummy hash
+            api_key="test-api-key",
         )
         db.session.add(user)
         db.session.commit()
-        db.session.expunge(user) # Detach it so it can be used outside
+        db.session.refresh(user)
+        db.session.expunge(user)
         return user

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,47 @@
+import pytest
+import importlib
+import config
+
+
+def test_config_no_secret_key_production(monkeypatch):
+    # Ensure SECRET_KEY is not in env
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    # Ensure FLASK_DEBUG is false
+    monkeypatch.setenv("FLASK_DEBUG", "false")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        importlib.reload(config)
+    assert (
+        "SECRET_KEY environment variable is not set and the app is not in debug mode."
+        in str(excinfo.value)
+    )
+
+
+def test_config_no_secret_key_debug(monkeypatch):
+    # Ensure SECRET_KEY is not in env
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    # Ensure FLASK_DEBUG is true
+    monkeypatch.setenv("FLASK_DEBUG", "true")
+
+    importlib.reload(config)
+    assert config.Config.SECRET_KEY == "dev-secret-key-do-not-use-in-production"
+
+
+def test_config_with_secret_key_production(monkeypatch):
+    # Set SECRET_KEY
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
+    # Ensure FLASK_DEBUG is false
+    monkeypatch.setenv("FLASK_DEBUG", "false")
+
+    importlib.reload(config)
+    assert config.Config.SECRET_KEY == "test-secret-key"
+
+
+def test_config_with_secret_key_debug(monkeypatch):
+    # Set SECRET_KEY
+    monkeypatch.setenv("SECRET_KEY", "test-secret-key")
+    # Ensure FLASK_DEBUG is true
+    monkeypatch.setenv("FLASK_DEBUG", "true")
+
+    importlib.reload(config)
+    assert config.Config.SECRET_KEY == "test-secret-key"


### PR DESCRIPTION
This PR addresses a security vulnerability where the application would silently fall back to a dynamically generated `SECRET_KEY` using `os.urandom(24)` if the environment variable was not set. While cryptographically secure, this behavior causes session tokens to be invalidated upon every application restart, leading to poor user experience and potential issues with long-lived sessions.

Changes:
- Modified `config.py` to enforce that `SECRET_KEY` must be provided via an environment variable when `FLASK_DEBUG` is disabled (production).
- Introduced a static, non-production fallback key (`dev-secret-key-do-not-use-in-production`) for use only when `FLASK_DEBUG` is enabled.
- Added a new test suite `tests/test_config.py` to verify these behaviors using `importlib.reload`.
- Fixed a `DetachedInstanceError` in `tests/conftest.py` that was causing flakes in the existing test suite.

Verification:
- Ran `PYTHONPATH=. python3 -m pytest` and all 13 tests passed.
- Verified `config.py` manually to ensure the logic is correct.
- Ran `black` and `ruff` for code quality.

---
*PR created automatically by Jules for task [17043131975346900744](https://jules.google.com/task/17043131975346900744) started by @arumes31*