### PR TITLE
[TEST] Missing error testing in cleanup_phishing_urls

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -13,6 +13,7 @@ import time
 import os
 from urllib.parse import urlparse
 import redis
+from sqlalchemy.exc import SQLAlchemyError
 
 # Redis cache configuration for GeoIP lookups
 _REDIS_URL = os.environ.get('RATELIMIT_STORAGE_URL', 'redis://localhost:6379')
@@ -123,8 +124,13 @@ def cleanup_phishing_urls():
         if removed_count > 0:
             db.session.commit()
             
-    except Exception: # nosec B110
-        pass
+    except (IOError, OSError) as e:
+        current_app.logger.error(f'File error during phishing cleanup: {e}')
+    except SQLAlchemyError as e:
+        db.session.rollback()
+        current_app.logger.error(f'Database error during phishing cleanup: {e}')
+    except Exception as e:
+        current_app.logger.error(f'Unexpected error during phishing cleanup: {e}')
 
 def get_blocked_domains():
     """Returns the set of blocked domains using the in-process cache."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,108 @@
+import pytest
+import os
+import tempfile
+from unittest.mock import patch, MagicMock
+from app.models import db, URL
+from app.utils import cleanup_phishing_urls
+
+def test_cleanup_phishing_urls_success(app):
+    # Setup test data
+    with app.app_context():
+        u1 = URL(short_code='CLEAN', long_url='https://google.com')
+        u2 = URL(short_code='PHISH', long_url='https://phishing.com/login')
+        u3 = URL(short_code='PHISHSUB', long_url='https://sub.evil.com/path')
+        db.session.add_all([u1, u2, u3])
+        db.session.commit()
+
+        # Create a temp blocked domains file
+        fd, path = tempfile.mkstemp()
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write('phishing.com\n')
+                f.write('evil.com\n')
+
+            app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+            app.config['BLOCKED_DOMAINS_PATH'] = path
+
+            cleanup_phishing_urls()
+
+            # Verify PHISH and PHISHSUB are removed, CLEAN remains
+            remaining = URL.query.all()
+            remaining_codes = [u.short_code for u in remaining]
+            assert 'CLEAN' in remaining_codes
+            assert 'PHISH' not in remaining_codes
+            assert 'PHISHSUB' not in remaining_codes
+        finally:
+            os.remove(path)
+
+def test_cleanup_phishing_urls_rotate_targets(app):
+    with app.app_context():
+        u1 = URL(short_code='ROTATE', long_url='https://google.com', rotate_targets=['https://safe.com', 'https://malware.org'])
+        db.session.add(u1)
+        db.session.commit()
+
+        fd, path = tempfile.mkstemp()
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write('malware.org\n')
+
+            app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+            app.config['BLOCKED_DOMAINS_PATH'] = path
+
+            cleanup_phishing_urls()
+
+            assert URL.query.filter_by(short_code='ROTATE').first() is None
+        finally:
+            os.remove(path)
+
+def test_cleanup_phishing_urls_file_error(app):
+    with app.app_context():
+        app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+        app.config['BLOCKED_DOMAINS_PATH'] = 'non_existent_file.txt'
+
+        # We need to mock os.path.exists to return True so it tries to open it
+        with patch('os.path.exists', return_value=True):
+            with patch('builtins.open', side_effect=OSError("Read error")):
+                with patch.object(app.logger, 'error') as mock_log:
+                    cleanup_phishing_urls()
+                    mock_log.assert_called_once()
+                    assert "File error" in mock_log.call_args[0][0]
+
+def test_cleanup_phishing_urls_db_error(app):
+    with app.app_context():
+        # Setup test data
+        u1 = URL(short_code='PHISH', long_url='https://phishing.com/login')
+        db.session.add(u1)
+        db.session.commit()
+
+        fd, path = tempfile.mkstemp()
+        try:
+            with os.fdopen(fd, 'w') as f:
+                f.write('phishing.com\n')
+
+            app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+            app.config['BLOCKED_DOMAINS_PATH'] = path
+
+            from sqlalchemy.exc import SQLAlchemyError
+            with patch('app.models.db.session.commit', side_effect=SQLAlchemyError("DB fail")):
+                with patch('app.models.db.session.rollback') as mock_rollback:
+                    with patch.object(app.logger, 'error') as mock_log:
+                        cleanup_phishing_urls()
+                        mock_rollback.assert_called_once()
+                        mock_log.assert_called_once()
+                        assert "Database error" in mock_log.call_args[0][0]
+        finally:
+            os.remove(path)
+
+def test_cleanup_phishing_urls_unexpected_error(app):
+    with app.app_context():
+        app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+        app.config['BLOCKED_DOMAINS_PATH'] = 'some_path'
+
+        with patch('os.path.exists', return_value=True):
+            # Raise an unexpected exception during file read
+            with patch('builtins.open', side_effect=Exception("Boom")):
+                with patch.object(app.logger, 'error') as mock_log:
+                    cleanup_phishing_urls()
+                    mock_log.assert_called_once()
+                    assert "Unexpected error" in mock_log.call_args[0][0]


### PR DESCRIPTION
Fixed missing error testing and handling in `cleanup_phishing_urls`.

Key changes:
1.  **Code Improvement**: Updated `app/utils.py` to catch specific exceptions (`IOError`, `OSError`, `SQLAlchemyError`) instead of a generic `Exception`. Added logging and database rollback logic.
2.  **New Tests**: Created `tests/test_utils.py` to test both the successful execution of `cleanup_phishing_urls` and its error-handling paths using mocks.
3.  **Bug Fix**: Resolved a `DetachedInstanceError` in `tests/conftest.py` that was causing failures in `tests/test_api_auth.py` by ensuring the user object is refreshed before being expunged from the session.

All 14 tests in the suite now pass.

---
*PR created automatically by Jules for task [16065681639467154548](https://jules.google.com/task/16065681639467154548) started by @arumes31*