### PR TITLE
🧹 [TEST] Missing edge case for select_rotate_target

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -112,7 +112,8 @@ def cleanup_phishing_urls():
                                 if '.'.join(parts[i:]) in blocked_domains:
                                     is_phishing = True
                                     break
-                        if is_phishing: break
+                        if is_phishing:
+                            break
 
                 if is_phishing:
                     db.session.delete(url_entry)
@@ -317,10 +318,17 @@ def select_rotate_target(rotate_targets):
     """Selects an alternate URL based on a simple rotation (hash of timestamp)."""
     if not rotate_targets:
         return None
+
+    if isinstance(rotate_targets, str):
+        return rotate_targets
+
+    if not isinstance(rotate_targets, list):
+        rotate_targets = list(rotate_targets)
+
     # Using microsecond for more "random" feel on rapid refreshes
     idx = hash(str(datetime.datetime.now().microsecond)) % len(rotate_targets)
-    return rotate_targets[idx]
 
+    return rotate_targets[idx]
 def get_qr_data_url(data, color='black', bg='white', logo_img=None):
     """Returns a base64 encoded data URL for the QR code."""
     img_buffer = generate_qr(data, color, bg, logo_img)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user) # Refresh attributes before expunging
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+import pytest
+from app.utils import select_rotate_target
+
+def test_select_rotate_target_empty():
+    assert select_rotate_target([]) is None
+    assert select_rotate_target(None) is None
+    assert select_rotate_target("") is None
+
+def test_select_rotate_target_list():
+    targets = ["http://a.com", "http://b.com"]
+    result = select_rotate_target(targets)
+    assert result in targets
+
+def test_select_rotate_target_string():
+    # Currently this fails (returns a character)
+    target = "http://example.com"
+    assert select_rotate_target(target) == target
+
+def test_select_rotate_target_set():
+    # Currently this fails (TypeError: 'set' object is not subscriptable)
+    targets = {"http://a.com", "http://b.com"}
+    result = select_rotate_target(targets)
+    assert result in targets


### PR DESCRIPTION
### What
- Modified `select_rotate_target` in `app/utils.py` to handle string inputs (returns the string) and non-list iterables (converts to list).
- Added `tests/test_utils.py` with 4 test cases.
- Fixed `DetachedInstanceError` in `tests/conftest.py` by adding `db.session.refresh(user)`.
- Fixed linting error in `app/utils.py` (E701).

### Why
- Prevented incorrect behavior (returning characters from strings) and crashes (with sets).
- Ensured test suite stability.

### Verification
- `pytest tests/test_utils.py`: Passed (4/4)
- `pytest`: Passed (13/13)
- `ruff check app/utils.py`: Passed
- `radon cc app/utils.py`: select_rotate_target has rank A (4)

### Result
Robust URL rotation utility and a healthy test environment.

---
*PR created automatically by Jules for task [1067134045696429426](https://jules.google.com/task/1067134045696429426) started by @arumes31*