### PR TITLE
[SECURITY] CSV Injection Vulnerability in Links Export

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -21,7 +21,7 @@ ratelimit_hits_total = Counter('redrx_ratelimit_hits_total', 'Total number of re
 
 from app.models import db, URL, User, Click
 from app.forms import ShortenURLForm, LoginForm, RegisterForm, LinkPasswordForm, EditURLForm
-from app.utils import generate_short_code, get_qr_data_url, generate_qr, select_rotate_target, get_geo_info, is_safe_url, get_client_ip, _get_redis_client, get_blocked_domains
+from app.utils import sanitize_csv_field, generate_short_code, get_qr_data_url, generate_qr, select_rotate_target, get_geo_info, is_safe_url, get_client_ip, _get_redis_client, get_blocked_domains
 
 main = Blueprint('main', __name__)
 
@@ -394,8 +394,8 @@ def export_links():
     
     for u in urls:
         writer.writerow([
-            u.short_code, 
-            u.long_url, 
+            sanitize_csv_field(u.short_code),
+            sanitize_csv_field(u.long_url),
             u.clicks_count, 
             u.created_at.isoformat(),
             u.last_accessed_at.isoformat() if u.last_accessed_at else 'Never',

--- a/app/utils.py
+++ b/app/utils.py
@@ -325,3 +325,12 @@ def get_qr_data_url(data, color='black', bg='white', logo_img=None):
     """Returns a base64 encoded data URL for the QR code."""
     img_buffer = generate_qr(data, color, bg, logo_img)
     return base64.b64encode(img_buffer.read()).decode()
+
+def sanitize_csv_field(value):
+    """Sanitizes a field for CSV export to prevent formula injection."""
+    if value is None:
+        return ""
+    str_val = str(value)
+    if str_val and str_val[0] in ('=', '+', '-', '@'):
+        return "'" + str_val
+    return str_val

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_csv_injection.py
+++ b/tests/test_csv_injection.py
@@ -1,0 +1,52 @@
+import pytest
+from app.models import db, URL, User
+from werkzeug.security import generate_password_hash
+
+def test_csv_export_sanitization(app, client):
+    # 1. Create a user and log in
+    with app.app_context():
+        user = User(
+            username='csvuser',
+            email='csv@example.com',
+            password_hash=generate_password_hash('password')
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        # 2. Create a URL with a malicious long_url (CSV injection)
+        malicious_url = URL(
+            short_code='DANGER',
+            long_url='=SUM(1,2)',
+            user_id=user.id
+        )
+        db.session.add(malicious_url)
+        db.session.commit()
+
+        # Log in the user
+        with client.session_transaction() as sess:
+            sess['_user_id'] = str(user.id)
+            sess['_fresh'] = True
+
+    # 3. Export links
+    response = client.get('/export-links')
+    assert response.status_code == 200
+
+    csv_data = response.data.decode('utf-8')
+
+    # Check if it's sanitized.
+    # The value should contain the prepended single quote.
+    assert "'=SUM(1,2)" in csv_data
+
+    # Verify it was applied to short_code too if it was malicious
+    with app.app_context():
+        malicious_code = URL(
+            short_code='+ATTACK',
+            long_url='https://example.com',
+            user_id=user.id
+        )
+        db.session.add(malicious_code)
+        db.session.commit()
+
+    response = client.get('/export-links')
+    csv_data = response.data.decode('utf-8')
+    assert "'+ATTACK" in csv_data


### PR DESCRIPTION
This pull request addresses a CSV injection vulnerability in the link export feature. Malicious target URLs or short codes containing spreadsheet formulas could execute when the exported CSV was opened in Excel or Google Sheets.

What was fixed:
- Implemented a `sanitize_csv_field` utility that prepends a single quote (`'`) to any string starting with `=`, `+`, `-`, or `@`.
- Integrated this sanitization into the `/export-links` route for the `short_code` and `long_url` fields.
- Added a new regression test `tests/test_csv_injection.py` to ensure continued protection.

Other changes:
- Fixed a `DetachedInstanceError` in `tests/conftest.py` by adding `db.session.refresh(user)` before expunging the user object, ensuring tests using the `test_user` fixture are stable.

Verification:
- Manually verified with a reproduction script.
- All tests in the suite passed (10 total).

---
*PR created automatically by Jules for task [8419843805582467645](https://jules.google.com/task/8419843805582467645) started by @arumes31*