### PR TITLE
[SECURITY] Open Redirect Vulnerability in Login

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The link shortening API allowed shortening of non-HTTP(S) URLs like `javascript:` and `data:` schemes, leading to Stored XSS.
 **Learning:** Even if frontend forms (like WTForms) use URL validators, the API layer must independently strictly validate the URL scheme (allowlisting `http` and `https`) to prevent malicious payloads from bypassing the UI.
 **Prevention:** Always enforce a strict scheme allowlist (`['http', 'https']`) on user-provided URLs at the backend/API level before accepting and storing them as redirects.
+## 2026-03-23 - Prevent Open Redirect in Login
+**Vulnerability:** The login route directly used the `next` query parameter in a `redirect()` call without validation, allowing attackers to redirect users to malicious external domains after a successful login.
+**Learning:** Redirect targets from user input must always be validated. For internal redirects, ensure the URL starts with a single `/` and not `//` (protocol-relative) to prevent redirects to external domains.
+**Prevention:** Use a helper like `is_safe_redirect_url` to validate all redirect targets that originate from request parameters.

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,12 +1,10 @@
 import io
 import csv
-import json
 import datetime
 import uuid
-from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, send_file, current_app, session, jsonify, send_from_directory
+from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, send_file, current_app, session, jsonify
 from flask_login import login_user, logout_user, current_user, login_required
-from flask_limiter import Limiter
-from app import limiter, metrics # Import metrics
+from app import limiter # Import metrics
 from werkzeug.security import generate_password_hash, check_password_hash
 from PIL import Image
 from user_agents import parse
@@ -21,7 +19,7 @@ ratelimit_hits_total = Counter('redrx_ratelimit_hits_total', 'Total number of re
 
 from app.models import db, URL, User, Click
 from app.forms import ShortenURLForm, LoginForm, RegisterForm, LinkPasswordForm, EditURLForm
-from app.utils import generate_short_code, get_qr_data_url, generate_qr, select_rotate_target, get_geo_info, is_safe_url, get_client_ip, _get_redis_client, get_blocked_domains
+from app.utils import is_safe_redirect_url, generate_short_code, get_qr_data_url, generate_qr, select_rotate_target, get_geo_info, is_safe_url, get_client_ip, _get_redis_client, get_blocked_domains
 
 main = Blueprint('main', __name__)
 
@@ -316,7 +314,9 @@ def login():
         if user and check_password_hash(user.password_hash, form.password.data):
             login_user(user)
             next_page = request.args.get('next')
-            return redirect(next_page) if next_page else redirect(url_for('main.index'))
+            if not is_safe_redirect_url(next_page):
+                next_page = url_for('main.index')
+            return redirect(next_page)
         else:
             flash('Login Unsuccessful. Please check username/email and password', 'danger')
     return render_template('login_user.html', form=form)

--- a/app/utils.py
+++ b/app/utils.py
@@ -325,3 +325,10 @@ def get_qr_data_url(data, color='black', bg='white', logo_img=None):
     """Returns a base64 encoded data URL for the QR code."""
     img_buffer = generate_qr(data, color, bg, logo_img)
     return base64.b64encode(img_buffer.read()).decode()
+
+def is_safe_redirect_url(target):
+    """Ensures that the redirect target is safe (not an open redirect)."""
+    if not target:
+        return False
+    # Ensure it's a relative URL and not a protocol-relative one
+    return target.startswith('/') and not target.startswith('//')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,58 @@
+import pytest
+from flask import url_for
+from app.models import User, db
+from werkzeug.security import generate_password_hash
+
+def test_login_open_redirect_fix(client, app):
+    # Create a test user
+    with app.app_context():
+        user = User(username='security_test', email='security@test.com', password_hash=generate_password_hash('password123'))
+        db.session.add(user)
+        db.session.commit()
+
+    # Attempt to login with an external 'next' parameter
+    malicious_url = 'https://malicious.com'
+    response = client.post('/login', data={
+        'username': 'security_test',
+        'password': 'password123'
+    }, query_string={'next': malicious_url}, follow_redirects=False)
+
+    # After fix, it should NOT redirect to malicious_url, but to index (/)
+    assert response.status_code == 302
+    assert response.location == 'http://localhost/' or response.location == '/'
+
+def test_login_protocol_relative_redirect_fix(client, app):
+    # Create a test user
+    with app.app_context():
+        # User already created in previous test if it persisted, but conftest uses in-memory db with fresh start per app fixture
+        user = User(username='security_test_2', email='security2@test.com', password_hash=generate_password_hash('password123'))
+        db.session.add(user)
+        db.session.commit()
+
+    # Attempt to login with a protocol-relative 'next' parameter
+    malicious_url = '//malicious.com'
+    response = client.post('/login', data={
+        'username': 'security_test_2',
+        'password': 'password123'
+    }, query_string={'next': malicious_url}, follow_redirects=False)
+
+    # After fix, it should NOT redirect to malicious_url, but to index (/)
+    assert response.status_code == 302
+    assert response.location == 'http://localhost/' or response.location == '/'
+
+def test_login_safe_redirect(client, app):
+    # Create a test user
+    with app.app_context():
+        user = User(username='security_test_safe', email='security_safe@test.com', password_hash=generate_password_hash('password123'))
+        db.session.add(user)
+        db.session.commit()
+
+    # Attempt to login with a safe 'next' parameter
+    safe_url = '/dashboard'
+    response = client.post('/login', data={
+        'username': 'security_test_safe',
+        'password': 'password123'
+    }, query_string={'next': safe_url}, follow_redirects=False)
+
+    assert response.status_code == 302
+    assert response.location.endswith(safe_url) or response.location == 'http://localhost' + safe_url


### PR DESCRIPTION
The login route was vulnerable to an open redirect because it directly used the `next` query parameter in a `redirect()` call without validation. This allowed an attacker to construct a URL that would redirect a user to a malicious external site after a successful login.

I fixed this by:
1. Adding a `is_safe_redirect_url` utility function that ensures a URL is relative (starts with `/` but not `//`).
2. Using this utility in the `login` route to validate the `next` parameter.
3. Adding automated tests to verify protection against external and protocol-relative redirects.
4. Cleaning up the test suite by fixing a `DetachedInstanceError` in `tests/conftest.py`.
5. Documenting the fix in the security journal (`.jules/sentinel.md`).

---
*PR created automatically by Jules for task [8110021186338377556](https://jules.google.com/task/8110021186338377556) started by @arumes31*