### PR TITLE
[TEST] Missing tests for API token validation

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,11 +1,10 @@
 from flask import Blueprint, request, jsonify, current_app
 from werkzeug.security import generate_password_hash
 from app.models import db, URL, User
-from app.utils import generate_short_code, generate_qr, is_safe_url
+from app.utils import generate_short_code, is_safe_url
 from app import limiter, csrf
 from app.routes import shortened_links_total # Import the custom counter
 import datetime
-import base64
 
 api = Blueprint('api', __name__, url_prefix='/api/v1')
 csrf.exempt(api)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user) # Refresh attributes before expunging
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -1,4 +1,3 @@
-import pytest
 from app.api import get_user_from_api_key
 from app.models import db, URL
 
@@ -57,3 +56,18 @@ def test_api_get_info_auth_invalid(client):
     response = client.get('/api/v1/TESTCODE',
                           headers={'X-API-KEY': 'invalid-key'})
     assert response.status_code == 401
+
+def test_get_user_from_api_key_empty(app, test_user):
+    with app.test_request_context(headers={'X-API-KEY': ''}):
+        user = get_user_from_api_key()
+        assert user is None
+
+def test_get_user_from_api_key_whitespace(app, test_user):
+    with app.test_request_context(headers={'X-API-KEY': '   '}):
+        user = get_user_from_api_key()
+        assert user is None
+
+def test_get_user_from_api_key_too_long(app, test_user):
+    with app.test_request_context(headers={'X-API-KEY': 'a' * 100}):
+        user = get_user_from_api_key()
+        assert user is None


### PR DESCRIPTION
Fixed missing tests for API token validation.
The following changes were made:
1.  **Fixed `tests/conftest.py`**: Added `db.session.refresh(user)` to the `test_user` fixture. This ensures that the user object's attributes are loaded from the database before it is expunged from the session, preventing `DetachedInstanceError` when accessing attributes like `user.id` or `user.api_key` in tests.
2.  **Enhanced `tests/test_api_auth.py`**: Added three new test cases for `get_user_from_api_key`:
    *   `test_get_user_from_api_key_empty`: Verifies that an empty `X-API-KEY` header returns `None`.
    *   `test_get_user_from_api_key_whitespace`: Verifies that a whitespace-only `X-API-KEY` header returns `None`.
    *   `test_get_user_from_api_key_too_long`: Verifies that an excessively long `X-API-KEY` header returns `None`.
3.  **Code Quality**: Used `ruff` to remove unused imports in `app/api.py` (`generate_qr`, `base64`) and `tests/test_api_auth.py` (`pytest`).
4.  **Verification**: Ran the full test suite and confirmed all 12 tests pass.

---
*PR created automatically by Jules for task [12416511250928065855](https://jules.google.com/task/12416511250928065855) started by @arumes31*