### PR TITLE
[FIX] Unused Import `generate_qr`

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,11 +1,10 @@
 from flask import Blueprint, request, jsonify, current_app
 from werkzeug.security import generate_password_hash
 from app.models import db, URL, User
-from app.utils import generate_short_code, generate_qr, is_safe_url
+from app.utils import generate_short_code, is_safe_url
 from app import limiter, csrf
 from app.routes import shortened_links_total # Import the custom counter
 import datetime
-import base64
 
 api = Blueprint('api', __name__, url_prefix='/api/v1')
 csrf.exempt(api)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user


### PR DESCRIPTION
Removed unused `generate_qr` and `base64` imports from `app/api.py` to clean up the namespace and improve readability. Verified with `ruff`. Also fixed a `DetachedInstanceError` in `tests/conftest.py` where a user object was being detached without being refreshed, causing test failures when accessing its attributes.

---
*PR created automatically by Jules for task [14101544526780678387](https://jules.google.com/task/14101544526780678387) started by @arumes31*