### PR TITLE
[TEST] Untested API url get info endpoint

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,11 +1,10 @@
 from flask import Blueprint, request, jsonify, current_app
 from werkzeug.security import generate_password_hash
 from app.models import db, URL, User
-from app.utils import generate_short_code, generate_qr, is_safe_url
+from app.utils import generate_short_code, is_safe_url
 from app import limiter, csrf
 from app.routes import shortened_links_total # Import the custom counter
 import datetime
-import base64
 
 api = Blueprint('api', __name__, url_prefix='/api/v1')
 csrf.exempt(api)
@@ -142,7 +141,7 @@ def get_url_info(short_code):
     return jsonify({
         'short_code': url_entry.short_code,
         'long_url': url_entry.long_url,
-        'clicks': url_entry.clicks,
+        'clicks': url_entry.clicks_count,
         'created_at': url_entry.created_at.isoformat(),
         'expires_at': url_entry.expires_at.isoformat() if url_entry.expires_at else None,
         'active': url_entry.is_active()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_api_get_info.py
+++ b/tests/test_api_get_info.py
@@ -1,0 +1,69 @@
+from app.models import db, URL
+
+def test_api_get_info_success(app, client, test_user):
+    # Create a URL first
+    with app.app_context():
+        url = URL(short_code='TESTCODE', long_url='https://google.com', user_id=test_user.id)
+        db.session.add(url)
+        db.session.commit()
+
+    response = client.get('/api/v1/TESTCODE',
+                          headers={'X-API-KEY': 'test-api-key'})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['short_code'] == 'TESTCODE'
+    assert data['long_url'] == 'https://google.com'
+    assert data['clicks'] == 0
+    assert 'created_at' in data
+    assert data['active'] is True
+
+def test_api_get_info_case_insensitive(app, client, test_user):
+    # Create a URL first
+    with app.app_context():
+        url = URL(short_code='TESTCODE', long_url='https://google.com', user_id=test_user.id)
+        db.session.add(url)
+        db.session.commit()
+
+    # Query with lowercase short code
+    response = client.get('/api/v1/testcode',
+                          headers={'X-API-KEY': 'test-api-key'})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['short_code'] == 'TESTCODE'
+
+def test_api_get_info_not_found(client, test_user):
+    response = client.get('/api/v1/NONEXISTENT',
+                          headers={'X-API-KEY': 'test-api-key'})
+    assert response.status_code == 404
+    assert response.get_json()['error'] == 'URL not found'
+
+def test_api_get_info_unauthorized_missing_key(client):
+    response = client.get('/api/v1/TESTCODE')
+    assert response.status_code == 401
+    assert response.get_json()['error'] == 'Valid API Key required. Access denied.'
+
+def test_api_get_info_unauthorized_invalid_key(client):
+    response = client.get('/api/v1/TESTCODE',
+                          headers={'X-API-KEY': 'invalid-key'})
+    assert response.status_code == 401
+    assert response.get_json()['error'] == 'Valid API Key required. Access denied.'
+
+def test_api_get_info_inactive_url(app, client, test_user):
+    # Create an inactive URL (expired)
+    import datetime
+    with app.app_context():
+        url = URL(
+            short_code='EXPIRED',
+            long_url='https://google.com',
+            user_id=test_user.id,
+            expires_at=datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=1)
+        )
+        db.session.add(url)
+        db.session.commit()
+
+    response = client.get('/api/v1/EXPIRED',
+                          headers={'X-API-KEY': 'test-api-key'})
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['short_code'] == 'EXPIRED'
+    assert data['active'] is False


### PR DESCRIPTION
This PR addresses the missing test coverage for the API's URL information retrieval endpoint (`GET /api/v1/<short_code>`).

Key changes:
1. **New Tests:** Created `tests/test_api_get_info.py` covering success cases, case-insensitivity, 404 errors, and unauthorized access.
2. **Bug Fix in `app/api.py`:** The `get_url_info` endpoint was incorrectly attempting to serialize the `clicks` relationship object instead of the `clicks_count` integer, which would cause a `TypeError`. This has been fixed.
3. **Fixture Fix in `tests/conftest.py`:** Added `db.session.refresh(user)` before `db.session.expunge(user)` in the `test_user` fixture to prevent `DetachedInstanceError` when accessing user attributes in tests.
4. **Code Quality:** Removed unused imports in `app/api.py` and the newly created test file.

All tests passed successfully.

---
*PR created automatically by Jules for task [7939404541974294474](https://jules.google.com/task/7939404541974294474) started by @arumes31*