### PR TITLE
[TEST] Missing tests for URL shortcode conflict resolution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_api_shorten.py
+++ b/tests/test_api_shorten.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch
+from app.models import db, URL
+
+def test_api_shorten_custom_code_collision(client, test_user):
+    # Setup: Create a URL with a known short code
+    headers = {'X-API-KEY': 'test-api-key'}
+    client.post('/api/v1/shorten', headers=headers, json={
+        'long_url': 'https://example.com/1',
+        'custom_code': 'TAKEN'
+    })
+
+    # Action: Try to use the same custom code
+    response = client.post('/api/v1/shorten', headers=headers, json={
+        'long_url': 'https://example.com/2',
+        'custom_code': 'TAKEN'
+    })
+
+    # Verification
+    assert response.status_code == 409
+    assert response.get_json()['error'] == 'Custom code already taken'
+
+def test_api_shorten_generated_code_collision(client, test_user):
+    headers = {'X-API-KEY': 'test-api-key'}
+
+    # Pre-populate the DB with a code that will collide
+    with client.application.app_context():
+        url = URL(short_code='COLLIDE', long_url='https://initial.com', user_id=test_user.id)
+        db.session.add(url)
+        db.session.commit()
+
+    # Mock generate_short_code to return 'COLLIDE' then 'UNIQUE'
+    with patch('app.api.generate_short_code') as mock_gen:
+        mock_gen.side_effect = ['COLLIDE', 'UNIQUE']
+
+        response = client.post('/api/v1/shorten', headers=headers, json={
+            'long_url': 'https://example.com/unique'
+        })
+
+        assert response.status_code == 201
+        data = response.get_json()
+        assert data['short_code'] == 'UNIQUE'
+        assert mock_gen.call_count == 2


### PR DESCRIPTION
This PR introduces comprehensive tests for URL shortcode conflict resolution in the API.

Specifically:
- Added `tests/test_api_shorten.py` covering:
    - Custom code collisions: Verifies that the API returns a 409 status code when a user attempts to use an already taken custom short code.
    - Generated code collisions: Uses mocking to simulate a collision during automatic short code generation, ensuring the API correctly retries and returns a unique code.
- Fixed a `DetachedInstanceError` in `tests/conftest.py` by adding `db.session.refresh(user)` before `db.session.expunge(user)`.
- Cleaned up unused imports in the new test file to satisfy linting requirements.

All tests (11 total) pass in the local environment.

---
*PR created automatically by Jules for task [4923051640450858409](https://jules.google.com/task/4923051640450858409) started by @arumes31*