### PR TITLE
[FIX] Unused Import TextAreaField

### DIFF
--- a/app/forms.py
+++ b/app/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileField, FileAllowed
-from wtforms import StringField, PasswordField, BooleanField, IntegerField, DateField, TimeField, TextAreaField, SubmitField
+from wtforms import StringField, PasswordField, BooleanField, IntegerField, DateField, TimeField, SubmitField
 from wtforms.validators import DataRequired, URL, Optional, Length, Email, NumberRange
 
 class ShortenURLForm(FlaskForm):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user


### PR DESCRIPTION
This PR removes the unused `TextAreaField` import from `wtforms` in `app/forms.py`. 

- Cleaned up `app/forms.py` by removing `TextAreaField`.
- Verified the fix using `ruff check`.
- Fixed a pre-existing `DetachedInstanceError` in `tests/conftest.py` that was preventing the test suite from passing.
- Successfully ran the test suite using `pytest`.

---
*PR created automatically by Jules for task [3137213851960575492](https://jules.google.com/task/3137213851960575492) started by @arumes31*