### PR TITLE
[TEST] Missing error testing in cleanup_phishing_urls

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,3 +1,4 @@
+from sqlalchemy.exc import SQLAlchemyError
 import uuid
 import qrcode
 import io
@@ -81,17 +82,25 @@ def cleanup_phishing_urls():
     from app.models import db, URL
     
     try:
-        with open(path, 'r', encoding='utf-8') as f:
-            blocked_domains = {line.strip().lower() for line in f if line.strip()}
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                blocked_domains = {line.strip().lower() for line in f if line.strip()}
+        except (IOError, OSError) as e:
+            current_app.logger.error(f"Failed to read phishing list at {path}: {e}")
+            return
 
         if not blocked_domains:
             return
 
-        urls = URL.query.all()
+        try:
+            urls = URL.query.all()
+        except SQLAlchemyError as e:
+            current_app.logger.error(f"Failed to query URLs for phishing cleanup: {e}")
+            return
+
         removed_count = 0
         
         for url_entry in urls:
-            # Check main long_url
             try:
                 domain = urlparse(url_entry.long_url).netloc.lower()
                 is_phishing = False
@@ -102,7 +111,6 @@ def cleanup_phishing_urls():
                             is_phishing = True
                             break
                 
-                # Check rotate_targets if main is clean
                 if not is_phishing and url_entry.rotate_targets:
                     for target in url_entry.rotate_targets:
                         target_domain = urlparse(target).netloc.lower()
@@ -112,19 +120,27 @@ def cleanup_phishing_urls():
                                 if '.'.join(parts[i:]) in blocked_domains:
                                     is_phishing = True
                                     break
-                        if is_phishing: break
+                        if is_phishing:
+                            break
 
                 if is_phishing:
                     db.session.delete(url_entry)
                     removed_count += 1
-            except Exception: # nosec B112
+            except Exception as e:
+                current_app.logger.error(f"Error processing URL {url_entry.id} during phishing cleanup: {e}")
                 continue
         
         if removed_count > 0:
-            db.session.commit()
+            try:
+                db.session.commit()
+                current_app.logger.info(f"Phishing cleanup removed {removed_count} URLs.")
+            except SQLAlchemyError as e:
+                db.session.rollback()
+                current_app.logger.error(f"Failed to commit phishing cleanup: {e}")
             
-    except Exception: # nosec B110
-        pass
+    except Exception as e:
+        current_app.logger.error(f"Unexpected error during phishing cleanup: {e}")
+        db.session.rollback()
 
 def get_blocked_domains():
     """Returns the set of blocked domains using the in-process cache."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,6 @@ def runner(app):
 
 @pytest.fixture
 def test_user(app):
-    # Returning a detached user object might still cause DetachedInstanceError.
-    # We'll return it and the tests will use its attributes.
     with app.app_context():
         user = User(
             username='testuser',
@@ -44,5 +42,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_phishing_cleanup.py
+++ b/tests/test_phishing_cleanup.py
@@ -1,0 +1,173 @@
+import os
+import tempfile
+import unittest.mock as mock
+from sqlalchemy.exc import SQLAlchemyError
+from app.models import db, URL
+from app.utils import cleanup_phishing_urls
+import logging
+
+def test_cleanup_phishing_disabled(app):
+    """Test that cleanup returns early if ENABLE_AUTO_REMOVE_PHISHING is False."""
+    app.config['ENABLE_AUTO_REMOVE_PHISHING'] = False
+    with mock.patch('app.utils.os.path.exists') as mock_exists:
+        cleanup_phishing_urls()
+        mock_exists.assert_not_called()
+
+def test_cleanup_missing_path(app):
+    """Test that cleanup returns early if BLOCKED_DOMAINS_PATH is not set or file missing."""
+    app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+    app.config['BLOCKED_DOMAINS_PATH'] = None
+    cleanup_phishing_urls() # Should not raise anything
+
+    app.config['BLOCKED_DOMAINS_PATH'] = '/non/existent/path'
+    cleanup_phishing_urls() # Should not raise anything
+
+def test_cleanup_file_read_error(app, caplog):
+    """Test handling of IOError/OSError when reading the phishing list."""
+    app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+    caplog.set_level(logging.ERROR)
+    with tempfile.NamedTemporaryFile() as tmp:
+        app.config['BLOCKED_DOMAINS_PATH'] = tmp.name
+        with mock.patch('app.utils.open', side_effect=IOError("Read error")):
+            cleanup_phishing_urls()
+            assert "Failed to read phishing list" in caplog.text
+
+def test_cleanup_empty_blocked_domains(app):
+    """Test that cleanup returns early if the phishing list is empty."""
+    app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
+        tmp.write("")
+        tmp_path = tmp.name
+
+    try:
+        app.config['BLOCKED_DOMAINS_PATH'] = tmp_path
+        with mock.patch('app.models.URL.query') as mock_query_class:
+             # We need to mock the whole query chain or just .all()
+             mock_all = mock_query_class.all
+             cleanup_phishing_urls()
+             mock_all.assert_not_called()
+    finally:
+        os.remove(tmp_path)
+
+def test_cleanup_db_query_error(app, caplog):
+    """Test handling of SQLAlchemyError during URL query."""
+    app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+    caplog.set_level(logging.ERROR)
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
+        tmp.write("phishing.com\n")
+        tmp_path = tmp.name
+
+    try:
+        app.config['BLOCKED_DOMAINS_PATH'] = tmp_path
+        with mock.patch('app.models.URL.query') as mock_query:
+            mock_query.all.side_effect = SQLAlchemyError("DB error")
+            cleanup_phishing_urls()
+            assert "Failed to query URLs for phishing cleanup" in caplog.text
+    finally:
+        os.remove(tmp_path)
+
+def test_cleanup_success(app):
+    """Test successful identification and removal of phishing URLs."""
+    app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
+        tmp.write("phish.com\n")
+        tmp.write("bad.org\n")
+        tmp_path = tmp.name
+
+    try:
+        app.config['BLOCKED_DOMAINS_PATH'] = tmp_path
+        with app.app_context():
+            url1 = URL(short_code='SAFE1', long_url='https://google.com')
+            url2 = URL(short_code='PHISH1', long_url='https://phish.com/login')
+            url3 = URL(short_code='SUBPHISH', long_url='https://sub.bad.org/path')
+            url4 = URL(short_code='ROTATEPHISH', long_url='https://safe.com')
+            url4.rotate_targets = ['https://malware.com', 'https://phish.com/target']
+
+            db.session.add_all([url1, url2, url3, url4])
+            db.session.commit()
+
+            cleanup_phishing_urls()
+
+            remaining = URL.query.all()
+            remaining_codes = [u.short_code for u in remaining]
+
+            assert 'SAFE1' in remaining_codes
+            assert 'PHISH1' not in remaining_codes
+            assert 'SUBPHISH' not in remaining_codes
+            assert 'ROTATEPHISH' not in remaining_codes
+    finally:
+        os.remove(tmp_path)
+
+def test_cleanup_commit_error(app, caplog):
+    """Test handling of SQLAlchemyError during commit and rollback."""
+    app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+    caplog.set_level(logging.ERROR)
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
+        tmp.write("phish.com\n")
+        tmp_path = tmp.name
+
+    try:
+        app.config['BLOCKED_DOMAINS_PATH'] = tmp_path
+        with app.app_context():
+            url = URL(short_code='PHISH2', long_url='https://phish.com')
+            db.session.add(url)
+            db.session.commit()
+
+            with mock.patch('app.models.db.session.commit', side_effect=SQLAlchemyError("Commit failed")):
+                cleanup_phishing_urls()
+                assert "Failed to commit phishing cleanup" in caplog.text
+
+                # Verify it wasn't deleted due to rollback
+                db.session.rollback() # Ensure session is clean
+                assert URL.query.filter_by(short_code='PHISH2').first() is not None
+    finally:
+        os.remove(tmp_path)
+
+def test_cleanup_processing_error(app, caplog):
+    """Test that error in processing one URL doesn't stop the whole process."""
+    app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+    caplog.set_level(logging.ERROR)
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
+        tmp.write("phish.com\n")
+        tmp_path = tmp.name
+
+    try:
+        app.config['BLOCKED_DOMAINS_PATH'] = tmp_path
+        with app.app_context():
+            url1 = URL(short_code='PHISH3', long_url='https://phish.com')
+            url2 = URL(short_code='SAFE2', long_url='https://google.com')
+            db.session.add_all([url1, url2])
+            db.session.commit()
+
+            # We need to trigger an exception during the loop.
+            # urlparse is used in the loop.
+            with mock.patch('app.utils.urlparse') as mock_urlparse:
+                # First call (url1) raises, second (url2) succeeds
+                # Actually urlparse is called once per URL.
+                mock_urlparse.side_effect = [Exception("Processing error"), mock.DEFAULT]
+                mock_urlparse.return_value = mock.Mock(netloc="google.com")
+
+                cleanup_phishing_urls()
+                assert "Error processing URL" in caplog.text
+
+            # SAFE2 should still exist
+            assert URL.query.filter_by(short_code='SAFE2').first() is not None
+    finally:
+        os.remove(tmp_path)
+
+def test_cleanup_unexpected_outer_error(app, caplog):
+    """Test handling of unexpected errors in the outer block."""
+    app.config['ENABLE_AUTO_REMOVE_PHISHING'] = True
+    caplog.set_level(logging.ERROR)
+    with tempfile.NamedTemporaryFile(mode='w', delete=False) as tmp:
+        tmp.write("phish.com\n")
+        tmp_path = tmp.name
+
+    try:
+        app.config['BLOCKED_DOMAINS_PATH'] = tmp_path
+        # Trigger unexpected error by mocking something fundamental
+        with mock.patch('app.utils.open', side_effect=RuntimeError("Outer disaster")):
+            cleanup_phishing_urls()
+            assert "Unexpected error during phishing cleanup" in caplog.text
+    finally:
+        os.remove(tmp_path)


### PR DESCRIPTION
This PR addresses the missing error testing and lack of robust error handling in the `cleanup_phishing_urls` function.

Key changes:
1.  **Robust Error Handling**: Refactored `cleanup_phishing_urls` in `app/utils.py` to explicitly catch and log `IOError`/`OSError` (for phishing list reading) and `SQLAlchemyError` (for database queries and commits).
2.  **Database Integrity**: Added `db.session.rollback()` calls to ensure the database session is correctly handled when errors occur during the cleanup process.
3.  **Comprehensive Testing**: Introduced `tests/test_phishing_cleanup.py` which mocks various failure points (missing files, read errors, database query failures, commit failures, and general processing errors) to ensure the logic handles them gracefully without crashing.
4.  **Bug Fix**: Resolved a `DetachedInstanceError` in the `test_user` fixture within `tests/conftest.py` by adding `db.session.refresh(user)` before `db.session.expunge(user)`.
5.  **Code Quality**: Addressed linting issues (unused imports and multi-statement lines) identified by `ruff`.

---
*PR created automatically by Jules for task [4748372092761948229](https://jules.google.com/task/4748372092761948229) started by @arumes31*