### PR TITLE
[TEST] Missing edge case for select_rotate_target

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -317,6 +317,13 @@ def select_rotate_target(rotate_targets):
     """Selects an alternate URL based on a simple rotation (hash of timestamp)."""
     if not rotate_targets:
         return None
+
+    if isinstance(rotate_targets, str):
+        return rotate_targets
+
+    if not isinstance(rotate_targets, list):
+        rotate_targets = list(rotate_targets)
+
     # Using microsecond for more "random" feel on rapid refreshes
     idx = hash(str(datetime.datetime.now().microsecond)) % len(rotate_targets)
     return rotate_targets[idx]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_utils_rotate.py
+++ b/tests/test_utils_rotate.py
@@ -1,0 +1,23 @@
+import pytest
+from app.utils import select_rotate_target
+
+def test_select_rotate_target_empty():
+    assert select_rotate_target([]) is None
+    assert select_rotate_target(None) is None
+    assert select_rotate_target("") is None
+
+def test_select_rotate_target_single_string():
+    url = "https://example.com"
+    # Current buggy behavior: returns a character
+    # Desired behavior: returns the string itself
+    assert select_rotate_target(url) == url
+
+def test_select_rotate_target_list():
+    targets = ["https://a.com", "https://b.com"]
+    result = select_rotate_target(targets)
+    assert result in targets
+
+def test_select_rotate_target_other_iterable():
+    targets = {"https://a.com", "https://b.com"}
+    result = select_rotate_target(targets)
+    assert result in targets


### PR DESCRIPTION
This PR fixes two issues:
1. select_rotate_target in app/utils.py was incorrectly handling non-list inputs. If a string was passed, it would return a single character due to indexing. If a non-subscriptable iterable (like a set) was passed, it would raise a TypeError. The function now returns strings directly and converts other iterables to lists before indexing.
2. A pre-existing DetachedInstanceError in the test suite was fixed in tests/conftest.py by adding db.session.refresh(user) before expunging the user in the test_user fixture.

Comprehensive tests for select_rotate_target were added in tests/test_utils_rotate.py.

---
*PR created automatically by Jules for task [8602305256776720316](https://jules.google.com/task/8602305256776720316) started by @arumes31*