### PR TITLE
[TEST] Missing tests for date parsing in API shorten

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_api_shorten.py
+++ b/tests/test_api_shorten.py
@@ -1,0 +1,58 @@
+import datetime
+
+def test_api_shorten_valid_dates(client, test_user):
+    start_at = (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=1)).isoformat()
+    end_at = (datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=2)).isoformat()
+
+    # Test with Z and +00:00
+    start_at_z = start_at.replace('+00:00', 'Z')
+
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://example.com',
+                               'start_at': start_at_z,
+                               'end_at': end_at
+                           })
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['start_at'] is not None
+    assert data['end_at'] is not None
+    # fromisoformat handles both Z (if replaced by +00:00 in code) and +00:00
+    assert data['start_at'].startswith(start_at_z[:-1]) or data['start_at'] == start_at
+    assert data['end_at'] == end_at
+
+def test_api_shorten_invalid_start_at(client, test_user):
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://example.com',
+                               'start_at': 'invalid-date'
+                           })
+
+    assert response.status_code == 400
+    assert response.get_json()['error'] == 'Invalid start_at format. Use ISO 8601'
+
+def test_api_shorten_invalid_end_at(client, test_user):
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://example.com',
+                               'end_at': 'not-a-date'
+                           })
+
+    assert response.status_code == 400
+    assert response.get_json()['error'] == 'Invalid end_at format. Use ISO 8601'
+
+def test_api_shorten_no_dates(client, test_user):
+    response = client.post('/api/v1/shorten',
+                           headers={'X-API-KEY': 'test-api-key'},
+                           json={
+                               'long_url': 'https://example.com'
+                           })
+
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data['start_at'] is None
+    assert data['end_at'] is None


### PR DESCRIPTION
Implemented comprehensive unit tests for date parsing in the `/api/v1/shorten` endpoint. 

The tests cover:
- Successful shortening with valid ISO 8601 `start_at` and `end_at` parameters (including 'Z' suffix support).
- Error handling (400 Bad Request) for invalid `start_at` formats.
- Error handling (400 Bad Request) for invalid `end_at` formats.
- Verification that dates are correctly returned in the JSON response when provided.

Additionally, fixed a `DetachedInstanceError` in the `test_user` fixture in `tests/conftest.py` by adding `db.session.refresh(user)` before expunging, ensuring attributes are available in tests. This fix ensures that existing API tests also pass correctly.

---
*PR created automatically by Jules for task [12758404855387052137](https://jules.google.com/task/12758404855387052137) started by @arumes31*