### PR TITLE
[FIX] Missing Rate Limiting on Authentication Endpoints

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,12 +1,10 @@
 import io
 import csv
-import json
 import datetime
 import uuid
-from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, send_file, current_app, session, jsonify, send_from_directory
+from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, send_file, current_app, session, jsonify
 from flask_login import login_user, logout_user, current_user, login_required
-from flask_limiter import Limiter
-from app import limiter, metrics # Import metrics
+from app import limiter # Import metrics
 from werkzeug.security import generate_password_hash, check_password_hash
 from PIL import Image
 from user_agents import parse
@@ -287,7 +285,7 @@ def link_password_auth(short_code):
     return render_template('login.html', form=form, short_code=short_code)
 
 @main.route('/register', methods=['GET', 'POST'])
-@limiter.limit("5 per hour") # Prevent spam accounts
+@limiter.limit(lambda: current_app.config.get("RATELIMIT_REGISTER", "5 per hour")) # Prevent spam accounts
 def register():
     if current_app.config.get('DISABLE_REGISTRATION'):
         flash("Registration is currently disabled.", 'info')
@@ -306,7 +304,7 @@ def register():
     return render_template('register.html', form=form)
 
 @main.route('/login', methods=['GET', 'POST'])
-@limiter.limit("10 per minute") # Prevent brute force
+@limiter.limit(lambda: current_app.config.get("RATELIMIT_LOGIN", "10 per minute")) # Prevent brute force
 def login():
     if current_user.is_authenticated:
         return redirect(url_for('main.index'))

--- a/config.py
+++ b/config.py
@@ -29,3 +29,7 @@ class Config:
     SEO_DOMAIN = os.environ.get('SEO_DOMAIN', 'redrx.eu')
     DEBUG = os.environ.get('FLASK_DEBUG', 'false').lower() in ['true', '1', 't']
 
+    # Rate Limiting
+    RATELIMIT_LOGIN = os.environ.get('RATELIMIT_LOGIN', '10 per minute')
+    RATELIMIT_REGISTER = os.environ.get('RATELIMIT_REGISTER', '5 per hour')
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user)
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_rate_limiting_auth.py
+++ b/tests/test_rate_limiting_auth.py
@@ -1,0 +1,28 @@
+
+def test_login_rate_limiting(app, client):
+    # Enable rate limiting for testing
+    app.config['RATELIMIT_ENABLED'] = True
+    # Set a very low rate limit for testing
+    app.config['RATELIMIT_LOGIN'] = '1 per minute'
+
+    # First request should succeed (200 OK)
+    response = client.get('/login')
+    assert response.status_code == 200
+
+    # Second request should be rate limited (429 Too Many Requests)
+    response = client.get('/login')
+    assert response.status_code == 429
+
+def test_register_rate_limiting(app, client):
+    # Enable rate limiting for testing
+    app.config['RATELIMIT_ENABLED'] = True
+    # Set a very low rate limit for testing
+    app.config['RATELIMIT_REGISTER'] = '1 per minute'
+
+    # First request should succeed (200 OK)
+    response = client.get('/register')
+    assert response.status_code == 200
+
+    # Second request should be rate limited (429 Too Many Requests)
+    response = client.get('/register')
+    assert response.status_code == 429


### PR DESCRIPTION
This PR adds dynamic rate limiting to the `/login` and `/register` endpoints in `app/routes.py`. It also introduces new configuration keys `RATELIMIT_LOGIN` and `RATELIMIT_REGISTER` in `config.py` with default values of '10 per minute' and '5 per hour' respectively. A new test file `tests/test_rate_limiting_auth.py` has been added to verify the fix. Additionally, a `DetachedInstanceError` in `tests/conftest.py` was resolved to ensure all tests pass correctly.

---
*PR created automatically by Jules for task [3002721569173796407](https://jules.google.com/task/3002721569173796407) started by @arumes31*