### PR TITLE
[TEST] Missing edge cases for geo ip info

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -1,3 +1,4 @@
+import ipaddress
 import uuid
 import qrcode
 import io
@@ -112,7 +113,8 @@ def cleanup_phishing_urls():
                                 if '.'.join(parts[i:]) in blocked_domains:
                                     is_phishing = True
                                     break
-                        if is_phishing: break
+                        if is_phishing:
+                            break
 
                 if is_phishing:
                     db.session.delete(url_entry)
@@ -226,6 +228,9 @@ def get_client_country(request):
 
 def get_geo_info(ip, request=None):
     """Fetches country from IP using local MaxMind database or Cloudflare header with Redis cache."""
+    if not ip:
+        return "Unknown"
+
     global _redis_client
     if _redis_client is None:
         _redis_client = _get_redis_client()
@@ -246,13 +251,17 @@ def get_geo_info(ip, request=None):
             # Update Cache if Redis is available
             if _redis_client:
                 try:
-                    _redis_client.setex(f"{_GEO_PREFIX}{ip}", _GEO_CACHE_TTL, cf_country)
+                    _redis_client.set(f"{_GEO_PREFIX}{ip}", cf_country, ex=_GEO_CACHE_TTL)
                 except Exception:
                     pass
             return cf_country
 
-    if ip == '127.0.0.1' or ip.startswith('192.168.') or ip.startswith('10.') or ip.startswith('172.'):
-        return "Local Network"
+    try:
+        ip_obj = ipaddress.ip_address(ip)
+        if ip_obj.is_loopback or ip_obj.is_private:
+            return "Local Network"
+    except ValueError:
+        return "Unknown"
     
     # 3. Check Local DB
     db_path = current_app.config.get('GEOIP_DB_PATH')
@@ -270,7 +279,7 @@ def get_geo_info(ip, request=None):
     # 4. Update Redis Cache
     if _redis_client:
         try:
-            _redis_client.setex(f"{_GEO_PREFIX}{ip}", _GEO_CACHE_TTL, country)
+            _redis_client.set(f"{_GEO_PREFIX}{ip}", country, ex=_GEO_CACHE_TTL)
         except Exception:
             pass
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,5 +44,6 @@ def test_user(app):
         )
         db.session.add(user)
         db.session.commit()
+        db.session.refresh(user) # Load attributes before expunge
         db.session.expunge(user) # Detach it so it can be used outside
         return user

--- a/tests/test_utils_geo.py
+++ b/tests/test_utils_geo.py
@@ -1,0 +1,85 @@
+from unittest.mock import MagicMock, patch
+from app.utils import get_geo_info
+import os
+
+def test_get_geo_info_none(app):
+    with app.app_context():
+        assert get_geo_info(None) == "Unknown"
+
+def test_get_geo_info_empty(app):
+    with app.app_context():
+        assert get_geo_info("") == "Unknown"
+
+def test_get_geo_info_invalid(app):
+    with app.app_context():
+        assert get_geo_info("not-an-ip") == "Unknown"
+
+def test_get_geo_info_local_ipv4(app):
+    with app.app_context():
+        assert get_geo_info("127.0.0.1") == "Local Network"
+        assert get_geo_info("10.0.0.1") == "Local Network"
+        assert get_geo_info("192.168.1.1") == "Local Network"
+        assert get_geo_info("172.16.0.1") == "Local Network"
+
+def test_get_geo_info_local_ipv6(app):
+    with app.app_context():
+        assert get_geo_info("::1") == "Local Network"
+        assert get_geo_info("fe80::1") == "Local Network"
+
+@patch('app.utils.get_client_country')
+def test_get_geo_info_cloudflare(mock_get_country, app):
+    mock_get_country.return_value = "US"
+    request = MagicMock()
+    with app.app_context():
+        assert get_geo_info("1.1.1.1", request=request) == "US"
+
+@patch('app.utils._redis_client')
+def test_get_geo_info_redis_cache(mock_redis, app):
+    mock_redis.get.return_value = "CachedCountry"
+    with app.app_context():
+        # Redis client is already initialized or mocked here
+        assert get_geo_info("8.8.8.8") == "CachedCountry"
+        mock_redis.get.assert_called_with("geo:8.8.8.8")
+
+@patch('geoip2.database.Reader')
+def test_get_geo_info_db_lookup(mock_reader_cls, app):
+    mock_reader = MagicMock()
+    mock_reader_cls.return_value.__enter__.return_value = mock_reader
+
+    mock_response = MagicMock()
+    mock_response.country.name = "United Kingdom"
+    mock_reader.country.return_value = mock_response
+
+    # Ensure DB path exists for the test
+    db_path = app.config.get('GEOIP_DB_PATH')
+    os.makedirs(os.path.dirname(db_path), exist_ok=True)
+    with open(db_path, 'w') as f:
+        f.write('dummy content')
+
+    try:
+        with app.app_context():
+            # Clear redis mock to ensure it doesn't return cached value
+            with patch('app.utils._redis_client', None):
+                assert get_geo_info("2.2.2.2") == "United Kingdom"
+    finally:
+        if os.path.exists(db_path):
+            os.remove(db_path)
+
+def test_get_geo_info_db_missing(app):
+    with app.app_context():
+        app.config['GEOIP_DB_PATH'] = '/non/existent/path'
+        # Patch redis to None to force DB lookup
+        with patch('app.utils._redis_client', None):
+            assert get_geo_info("1.1.1.1") == "Unknown (DB Missing)"
+
+@patch('app.utils._get_redis_client')
+def test_get_geo_info_redis_failure(mock_get_redis, app):
+    mock_redis = MagicMock()
+    mock_redis.get.side_effect = Exception("Redis Down")
+    mock_get_redis.return_value = mock_redis
+
+    with app.app_context():
+        # Should fallback and not crash
+        # Since DB is missing in test env by default, it should return Unknown (DB Missing)
+        app.config['GEOIP_DB_PATH'] = '/non/existent/path'
+        assert get_geo_info("8.8.8.8") == "Unknown (DB Missing)"


### PR DESCRIPTION
This PR addresses missing edge cases in the GeoIP lookup logic. 

Key changes:
1.  **Refactored `get_geo_info`**:
    *   Added checks for `None` or empty string IP addresses.
    *   Integrated the `ipaddress` module for robust detection of loopback and private network addresses (IPv4 and IPv6).
    *   Added error handling for invalid IP strings to prevent crashes.
    *   Updated Redis caching to use the modern `set(..., ex=...)` instead of the deprecated `setex`.
2.  **New Test Suite**:
    *   Created `tests/test_utils_geo.py` with 10 unit tests covering all identified edge cases and integration points (Cloudflare headers, Redis cache, local DB).
3.  **Bug Fix**:
    *   Fixed a `DetachedInstanceError` in the `test_user` fixture within `tests/conftest.py` by calling `db.session.refresh(user)` before `db.session.expunge(user)`.
4.  **Code Quality**:
    *   Resolved PEP 8 linting issues (E701) in `app/utils.py`.
    *   Cleaned up unused imports in the new test file.

---
*PR created automatically by Jules for task [15858815186890545641](https://jules.google.com/task/15858815186890545641) started by @arumes31*