### PR TITLE
[FIX] Unused Import Cleanup

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -543,8 +543,6 @@ def _get_relative_time(ts, now):
 def _process_analytics(url_id, range_type, now):
     from sqlalchemy import func
     from app.models import db, Click
-    from urllib.parse import urlparse
-    import datetime
 
     cutoff, sqlite_format, pg_format, time_data, days_in_range = _get_time_range_config(range_type, now)
 

--- a/tests/test_phishing_cleanup.py
+++ b/tests/test_phishing_cleanup.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from app.models import db, URL
 from app.utils import cleanup_phishing_urls
 

--- a/tests/test_stats_perf.py
+++ b/tests/test_stats_perf.py
@@ -1,6 +1,5 @@
 import re
 from urllib.parse import urlparse
-import pytest
 from app.models import db, URL, Click
 from datetime import datetime, timedelta, timezone
 

--- a/tests/test_utils_rotate.py
+++ b/tests/test_utils_rotate.py
@@ -1,4 +1,3 @@
-import pytest
 from app.utils import select_rotate_target
 
 def test_select_rotate_target_empty():

--- a/tests/test_utils_security.py
+++ b/tests/test_utils_security.py
@@ -1,5 +1,3 @@
-import os
-import pytest
 from app.utils import is_safe_url
 
 def test_is_safe_url_blocked_env(app, monkeypatch):


### PR DESCRIPTION
This PR cleans up several unused imports across the codebase. 

While the initial report regarding `app/api.py` was already addressed in the current branch, a project-wide linting check identified several other instances of unused imports that cluttered the namespace.

Changes:
- Confirmed `app/api.py` is free of unused `generate_qr`.
- Removed unused `urllib.parse.urlparse` and redundant `datetime` / `urlparse` imports in `app/routes.py`.
- Removed unused `os` and `pytest` imports in various test files.
- Verified that the application remains functional and all tests pass.

---
*PR created automatically by Jules for task [17049239070012595791](https://jules.google.com/task/17049239070012595791) started by @arumes31*