### PR TITLE
[SECURITY] CSV Injection Vulnerability in Links Export

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -20,6 +20,7 @@ ratelimit_hits_total = Counter('redrx_ratelimit_hits_total', 'Total number of re
 from app.models import db, URL, User, Click
 from app.forms import ShortenURLForm, LoginForm, RegisterForm, LinkPasswordForm, EditURLForm
 from app.utils import (
+    sanitize_csv_field,
     generate_short_code, get_qr_data_url, generate_qr, select_rotate_target,
     get_geo_info, is_safe_url, get_client_ip, _get_redis_client, is_safe_redirect_url,
     get_blocked_domains
@@ -396,15 +397,16 @@ def export_links():
     writer = csv.writer(output)
     writer.writerow(['Short Code', 'Long URL', 'Clicks', 'Created At', 'Last Accessed', 'Expires At'])
     
+
     for u in urls:
-        writer.writerow([
+        writer.writerow([sanitize_csv_field(f) for f in [
             u.short_code, 
             u.long_url, 
             u.clicks_count, 
             u.created_at.isoformat(),
             u.last_accessed_at.isoformat() if u.last_accessed_at else 'Never',
             u.expires_at.isoformat() if u.expires_at else 'Never'
-        ])
+        ]])
     
     output.seek(0)
     return send_file(

--- a/app/utils.py
+++ b/app/utils.py
@@ -319,6 +319,15 @@ def get_geo_info(ip, request=None):
 
     return country
 
+def sanitize_csv_field(value):
+    """
+    Escapes a value for CSV export to prevent CSV injection.
+    Prepend a single quote if the value starts with =, +, -, or @.
+    """
+    if isinstance(value, str) and value and value[0] in ("=", "+", "-", "@"):
+        return f"'{value}"
+    return value
+
 def generate_short_code(length=6):
     """Generates a random short code."""
     return str(uuid.uuid4())[:length].upper()

--- a/tests/test_csv_injection.py
+++ b/tests/test_csv_injection.py
@@ -1,0 +1,12 @@
+import pytest
+from app.utils import sanitize_csv_field
+
+def test_sanitize_csv_field():
+    assert sanitize_csv_field("=SUM(1,2)") == "'=SUM(1,2)"
+    assert sanitize_csv_field("+123") == "'+123"
+    assert sanitize_csv_field("-456") == "'-456"
+    assert sanitize_csv_field("@something") == "'@something"
+    assert sanitize_csv_field("normal") == "normal"
+    assert sanitize_csv_field(123) == 123
+    assert sanitize_csv_field(None) is None
+    assert sanitize_csv_field("") == ""


### PR DESCRIPTION
This PR addresses a CSV injection vulnerability in the link export feature. 

The `export_links` function previously wrote user-provided data directly to a CSV file without sanitization. An attacker could potentially craft a long URL starting with formula-triggering characters (like `=`, `+`, `-`, or `@`), which spreadsheet applications might execute when the exported CSV is opened.

Changes:
- Introduced `sanitize_csv_field` in `app/utils.py` to prepend a single quote (`'`) to any string field starting with formula characters.
- Applied this sanitization to all fields in the `export_links` route in `app/routes.py`.
- Added unit tests in `tests/test_csv_injection.py` to ensure the sanitization works as expected for various inputs.

---
*PR created automatically by Jules for task [10016345075780523997](https://jules.google.com/task/10016345075780523997) started by @arumes31*