### PR TITLE
[TEST] Missing tests for date parsing in API shorten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ TODO.md
 __pycache__/
 .pytest_cache
 temp/
+blocked_domains.txt
+pytest_output.log
+__pycache__/

--- a/tests/test_api_shorten.py
+++ b/tests/test_api_shorten.py
@@ -42,3 +42,51 @@ def test_api_shorten_generated_code_collision(client, test_user):
         data = response.get_json()
         assert data['short_code'] == 'UNIQUE'
         assert mock_gen.call_count == 2
+
+def test_api_shorten_valid_dates(client, test_user):
+    headers = {'X-API-KEY': 'test-api-key'}
+    start_at = "2025-01-01T00:00:00Z"
+    end_at = "2025-12-31T23:59:59+00:00"
+
+    response = client.post('/api/v1/shorten', headers=headers, json={
+        'long_url': 'https://example.com',
+        'start_at': start_at,
+        'end_at': end_at
+    })
+
+    assert response.status_code == 201
+    data = response.get_json()
+    # fromisoformat(start_at.replace('Z', '+00:00')).isoformat() -> '2025-01-01T00:00:00+00:00'
+    assert data['start_at'] == '2025-01-01T00:00:00+00:00'
+    assert data['end_at'] == '2025-12-31T23:59:59+00:00'
+
+def test_api_shorten_invalid_start_at(client, test_user):
+    headers = {'X-API-KEY': 'test-api-key'}
+    response = client.post('/api/v1/shorten', headers=headers, json={
+        'long_url': 'https://example.com',
+        'start_at': 'invalid-date'
+    })
+
+    assert response.status_code == 400
+    assert response.get_json()['error'] == 'Invalid start_at format. Use ISO 8601'
+
+def test_api_shorten_invalid_end_at(client, test_user):
+    headers = {'X-API-KEY': 'test-api-key'}
+    response = client.post('/api/v1/shorten', headers=headers, json={
+        'long_url': 'https://example.com',
+        'end_at': 'invalid-date'
+    })
+
+    assert response.status_code == 400
+    assert response.get_json()['error'] == 'Invalid end_at format. Use ISO 8601'
+
+def test_api_shorten_invalid_window(client, test_user):
+    headers = {'X-API-KEY': 'test-api-key'}
+    response = client.post('/api/v1/shorten', headers=headers, json={
+        'long_url': 'https://example.com',
+        'start_at': '2025-12-31T23:59:59Z',
+        'end_at': '2025-01-01T00:00:00Z'
+    })
+
+    assert response.status_code == 400
+    assert response.get_json()['error'] == 'Invalid scheduling window: end_at must be after start_at'


### PR DESCRIPTION
This PR adds comprehensive test coverage for ISO 8601 date parsing in the `/api/v1/shorten` endpoint. 

Specifically, it addresses the untested code path in `app/api.py` that handles `start_at` and `end_at` parameters.

Key changes:
- Added `test_api_shorten_valid_dates` to verify correct parsing of ISO 8601 strings (including the 'Z' UTC suffix).
- Added `test_api_shorten_invalid_start_at` and `test_api_shorten_invalid_end_at` to verify error handling for malformed date strings.
- Added `test_api_shorten_invalid_window` to verify that the endpoint correctly rejects logical errors where the start time is after the end time.
- Updated `.gitignore` to exclude `blocked_domains.txt` and other test artifacts to keep the repository clean.

---
*PR created automatically by Jules for task [13841892581234199001](https://jules.google.com/task/13841892581234199001) started by @arumes31*