### PR TITLE
[FIX] Unused Import metrics and PEP 8 Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ TODO.md
 __pycache__/
 .pytest_cache
 temp/
+blocked_domains.txt

--- a/app/routes.py
+++ b/app/routes.py
@@ -2,21 +2,16 @@ import io
 import csv
 import datetime
 import uuid
+from urllib.parse import urlparse
 from flask import Blueprint, render_template, request, redirect, url_for, flash, abort, send_file, current_app, session, jsonify
 from flask_login import login_user, logout_user, current_user, login_required
-from app import limiter
 from werkzeug.security import generate_password_hash, check_password_hash
 from PIL import Image
 from user_agents import parse
-from urllib.parse import urlparse
 from sqlalchemy import func, text
 from prometheus_client import Counter
 
-# Custom Metrics
-shortened_links_total = Counter('redrx_shortened_links_total', 'Total number of shortened links created')
-redirections_total = Counter('redrx_redirections_total', 'Total number of link redirections')
-ratelimit_hits_total = Counter('redrx_ratelimit_hits_total', 'Total number of requests hitting the rate limit')
-
+from app import limiter
 from app.models import db, URL, User, Click
 from app.forms import ShortenURLForm, LoginForm, RegisterForm, LinkPasswordForm, EditURLForm
 from app.utils import (
@@ -24,6 +19,11 @@ from app.utils import (
     get_geo_info, is_safe_url, get_client_ip, _get_redis_client, is_safe_redirect_url,
     get_blocked_domains
 )
+
+# Custom Metrics
+shortened_links_total = Counter('redrx_shortened_links_total', 'Total number of shortened links created')
+redirections_total = Counter('redrx_redirections_total', 'Total number of link redirections')
+ratelimit_hits_total = Counter('redrx_ratelimit_hits_total', 'Total number of requests hitting the rate limit')
 
 main = Blueprint('main', __name__)
 
@@ -488,7 +488,6 @@ def delete_url(short_code):
 
 
 def _get_time_range_config(range_type, now):
-    import datetime
     if range_type == '24h':
         cutoff = now - datetime.timedelta(hours=24)
         days = 1
@@ -529,7 +528,6 @@ def _anonymize_ip(ip):
     return 'xxxx'
 
 def _get_relative_time(ts, now):
-    import datetime
     ts_aware = ts.replace(tzinfo=datetime.timezone.utc) if ts.tzinfo is None else ts
     diff = now - ts_aware
     if diff.days > 0:
@@ -541,10 +539,6 @@ def _get_relative_time(ts, now):
     return 'Just now'
 
 def _process_analytics(url_id, range_type, now):
-    from sqlalchemy import func
-    from app.models import db, Click
-    from urllib.parse import urlparse
-    import datetime
 
     cutoff, sqlite_format, pg_format, time_data, days_in_range = _get_time_range_config(range_type, now)
 

--- a/tests/test_phishing_cleanup.py
+++ b/tests/test_phishing_cleanup.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from app.models import db, URL
 from app.utils import cleanup_phishing_urls
 

--- a/tests/test_stats_perf.py
+++ b/tests/test_stats_perf.py
@@ -1,6 +1,5 @@
 import re
 from urllib.parse import urlparse
-import pytest
 from app.models import db, URL, Click
 from datetime import datetime, timedelta, timezone
 

--- a/tests/test_utils_rotate.py
+++ b/tests/test_utils_rotate.py
@@ -1,4 +1,3 @@
-import pytest
 from app.utils import select_rotate_target
 
 def test_select_rotate_target_empty():

--- a/tests/test_utils_security.py
+++ b/tests/test_utils_security.py
@@ -1,5 +1,3 @@
-import os
-import pytest
 from app.utils import is_safe_url
 
 def test_is_safe_url_blocked_env(app, monkeypatch):


### PR DESCRIPTION
Removed unused imports in `app/routes.py` and test files. Moved module-level imports to the top in `app/routes.py` to comply with PEP 8 (E402). Resolved redundant local imports in `app/routes.py`. Verified changes with `ruff` and full test suite.

---
*PR created automatically by Jules for task [4769450264704371924](https://jules.google.com/task/4769450264704371924) started by @arumes31*