### PR TITLE
[FIX] Unused Import `TextAreaField` and general import cleanup

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -12,11 +12,6 @@ from urllib.parse import urlparse
 from sqlalchemy import func, text
 from prometheus_client import Counter
 
-# Custom Metrics
-shortened_links_total = Counter('redrx_shortened_links_total', 'Total number of shortened links created')
-redirections_total = Counter('redrx_redirections_total', 'Total number of link redirections')
-ratelimit_hits_total = Counter('redrx_ratelimit_hits_total', 'Total number of requests hitting the rate limit')
-
 from app.models import db, URL, User, Click
 from app.forms import ShortenURLForm, LoginForm, RegisterForm, LinkPasswordForm, EditURLForm
 from app.utils import (
@@ -24,6 +19,11 @@ from app.utils import (
     get_geo_info, is_safe_url, get_client_ip, _get_redis_client, is_safe_redirect_url,
     get_blocked_domains
 )
+
+# Custom Metrics
+shortened_links_total = Counter('redrx_shortened_links_total', 'Total number of shortened links created')
+redirections_total = Counter('redrx_redirections_total', 'Total number of link redirections')
+ratelimit_hits_total = Counter('redrx_ratelimit_hits_total', 'Total number of requests hitting the rate limit')
 
 main = Blueprint('main', __name__)
 
@@ -543,8 +543,6 @@ def _get_relative_time(ts, now):
 def _process_analytics(url_id, range_type, now):
     from sqlalchemy import func
     from app.models import db, Click
-    from urllib.parse import urlparse
-    import datetime
 
     cutoff, sqlite_format, pg_format, time_data, days_in_range = _get_time_range_config(range_type, now)
 

--- a/tests/test_phishing_cleanup.py
+++ b/tests/test_phishing_cleanup.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from app.models import db, URL
 from app.utils import cleanup_phishing_urls
 

--- a/tests/test_stats_perf.py
+++ b/tests/test_stats_perf.py
@@ -1,6 +1,5 @@
 import re
 from urllib.parse import urlparse
-import pytest
 from app.models import db, URL, Click
 from datetime import datetime, timedelta, timezone
 

--- a/tests/test_utils_rotate.py
+++ b/tests/test_utils_rotate.py
@@ -1,4 +1,3 @@
-import pytest
 from app.utils import select_rotate_target
 
 def test_select_rotate_target_empty():

--- a/tests/test_utils_security.py
+++ b/tests/test_utils_security.py
@@ -1,5 +1,3 @@
-import os
-import pytest
 from app.utils import is_safe_url
 
 def test_is_safe_url_blocked_env(app, monkeypatch):


### PR DESCRIPTION
Removed unused imports across the codebase to improve readability and clean up the namespace.

- Verified that `TextAreaField` was already absent from `app/forms.py`.
- Removed unused imports in `app/routes.py`, including `urlparse` and `datetime`.
- Fixed module-level import order in `app/routes.py` to adhere to PEP 8 (E402).
- Removed unused `os` and `pytest` imports in various test files.
- Verified all changes with `ruff check` and `pytest` (all 48 tests passed).

---
*PR created automatically by Jules for task [16160749403769833282](https://jules.google.com/task/16160749403769833282) started by @arumes31*