### PR TITLE
[TEST] Missing edge case for select_rotate_target

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -369,6 +369,9 @@ def select_rotate_target(rotate_targets):
     if not isinstance(rotate_targets, list):
         rotate_targets = list(rotate_targets)
 
+    if not rotate_targets:
+        return None
+
     # Using microsecond for more "random" feel on rapid refreshes
     idx = hash(str(datetime.datetime.now().microsecond)) % len(rotate_targets)
     return rotate_targets[idx]

--- a/tests/test_utils_rotate.py
+++ b/tests/test_utils_rotate.py
@@ -18,3 +18,8 @@ def test_select_rotate_target_other_iterable():
     targets = {"https://a.com", "https://b.com"}
     result = select_rotate_target(targets)
     assert result in targets
+
+def test_select_rotate_target_empty_generator():
+    def empty_gen():
+        yield from []
+    assert select_rotate_target(empty_gen()) is None


### PR DESCRIPTION
Fixed a `ZeroDivisionError` in `select_rotate_target` when passing an empty iterable (like a generator) that is truthy but becomes empty after conversion to a list. Added a test case to verify the fix.

---
*PR created automatically by Jules for task [3030635852347054006](https://jules.google.com/task/3030635852347054006) started by @arumes31*