### PR TITLE
[TEST] Untested QR generator fallback

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -278,7 +278,7 @@ def _is_local_ip(ip):
     try:
         ip_obj = ipaddress.ip_address(ip)
         return ip_obj.is_private or ip_obj.is_loopback
-    except ValueError:
+    except (ValueError, TypeError):
         return False
 
 def _get_db_geo(ip):
@@ -335,7 +335,7 @@ def generate_qr(data, color='black', bg='white', logo_img=None):
     # but PIL handles standard color names and hex codes well.
     try:
         img = qr.make_image(fill_color=color, back_color=bg).convert('RGB')
-    except ValueError:
+    except (ValueError, TypeError):
         # Fallback to defaults on error
         img = qr.make_image(fill_color='black', back_color='white').convert('RGB')
 

--- a/tests/test_utils_qr.py
+++ b/tests/test_utils_qr.py
@@ -44,3 +44,11 @@ def test_generate_qr_with_logo():
     assert isinstance(buffer, io.BytesIO)
     img = Image.open(buffer)
     assert img.format == 'PNG'
+
+def test_generate_qr_type_error_fallback():
+    """Test QR generation fallback when invalid types are provided for colors."""
+    # This should trigger the TypeError in app/utils.py and fall back to black/white
+    buffer = generate_qr("https://example.com", color=[1, 2, 3])
+    assert isinstance(buffer, io.BytesIO)
+    img = Image.open(buffer)
+    assert img.format == 'PNG'


### PR DESCRIPTION
This PR improves the robustness of the QR code generation fallback in app/utils.py and adds corresponding test coverage. PIL can raise TypeError in addition to ValueError for invalid color inputs, so the fallback now catches both. Tests have been updated to verify both scenarios.

---
*PR created automatically by Jules for task [11053796040306523358](https://jules.google.com/task/11053796040306523358) started by @arumes31*