### PR TITLE
[FIX] Unused Import generate_qr and project-wide cleanup

### DIFF
--- a/tests/test_csv_injection.py
+++ b/tests/test_csv_injection.py
@@ -1,6 +1,5 @@
 import io
 import csv
-import pytest
 from app.models import db, URL
 
 def test_csv_export_sanitization(client, app, test_user):

--- a/tests/test_index_refactor.py
+++ b/tests/test_index_refactor.py
@@ -1,6 +1,4 @@
-import pytest
 from app.models import db, URL
-from flask import url_for
 import datetime
 
 def test_index_get(client):

--- a/tests/test_phishing_cleanup.py
+++ b/tests/test_phishing_cleanup.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from unittest.mock import patch, MagicMock
 from app.models import db, URL
 from app.utils import cleanup_phishing_urls

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,7 +1,5 @@
 import pytest
-import time
 from app import create_app, db, limiter
-from app.models import User
 from config import Config
 
 class TestConfig(Config):

--- a/tests/test_redirection.py
+++ b/tests/test_redirection.py
@@ -1,6 +1,4 @@
-import pytest
 from app.models import db, URL, Click
-from flask import session
 import datetime
 
 def test_basic_redirection(client, app):

--- a/tests/test_stats_access.py
+++ b/tests/test_stats_access.py
@@ -1,4 +1,3 @@
-import pytest
 from app.models import db, URL
 
 def test_stats_access_owner(client, app, test_user):


### PR DESCRIPTION
Analysis of app/api.py confirmed that the reported unused import generate_qr was already absent from the codebase. However, a project-wide linting pass identified and resolved 9 other unused imports within the tests/ directory. Verified app/api.py namespace is clean of generate_qr. Removed unused imports (pytest, os, flask.url_for, flask.session, time, app.models.User) from various test files. Validated all changes with the full test suite (92/92 passed).

---
*PR created automatically by Jules for task [150169707119909926](https://jules.google.com/task/150169707119909926) started by @arumes31*