### PR TITLE
[FIX] Unused Import `base64`

### DIFF
--- a/tests/test_csv_injection.py
+++ b/tests/test_csv_injection.py
@@ -1,6 +1,5 @@
 import io
 import csv
-import pytest
 from app.models import db, URL
 
 def test_csv_export_sanitization(client, app, test_user):

--- a/tests/test_index_refactor.py
+++ b/tests/test_index_refactor.py
@@ -1,6 +1,4 @@
-import pytest
 from app.models import db, URL
-from flask import url_for
 import datetime
 
 def test_index_get(client):

--- a/tests/test_phishing_cleanup.py
+++ b/tests/test_phishing_cleanup.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from unittest.mock import patch, MagicMock
 from app.models import db, URL
 from app.utils import cleanup_phishing_urls

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,7 +1,5 @@
 import pytest
-import time
 from app import create_app, db, limiter
-from app.models import User
 from config import Config
 
 class TestConfig(Config):

--- a/tests/test_redirection.py
+++ b/tests/test_redirection.py
@@ -1,6 +1,4 @@
-import pytest
 from app.models import db, URL, Click
-from flask import session
 import datetime
 
 def test_basic_redirection(client, app):

--- a/tests/test_stats_access.py
+++ b/tests/test_stats_access.py
@@ -1,4 +1,3 @@
-import pytest
 from app.models import db, URL
 
 def test_stats_access_owner(client, app, test_user):


### PR DESCRIPTION
The reported unused import `base64` in `app/api.py` was already absent in the current codebase. However, a project-wide linting check with `ruff` identified several other unused imports in the `tests/` directory.

Changes:
- Removed unused imports in:
  - `tests/test_csv_injection.py`
  - `tests/test_index_refactor.py`
  - `tests/test_phishing_cleanup.py`
  - `tests/test_ratelimit.py`
  - `tests/test_redirection.py`
  - `tests/test_stats_access.py`
- Verified that `app/api.py` is clean.
- Confirmed all 92 tests pass.

---
*PR created automatically by Jules for task [407877979569430208](https://jules.google.com/task/407877979569430208) started by @arumes31*