### PR TITLE
[FIX] Unused Import `metrics` and test cleanup

### DIFF
--- a/tests/test_csv_injection.py
+++ b/tests/test_csv_injection.py
@@ -1,6 +1,5 @@
 import io
 import csv
-import pytest
 from app.models import db, URL
 
 def test_csv_export_sanitization(client, app, test_user):

--- a/tests/test_index_refactor.py
+++ b/tests/test_index_refactor.py
@@ -1,6 +1,4 @@
-import pytest
 from app.models import db, URL
-from flask import url_for
 import datetime
 
 def test_index_get(client):

--- a/tests/test_phishing_cleanup.py
+++ b/tests/test_phishing_cleanup.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from unittest.mock import patch, MagicMock
 from app.models import db, URL
 from app.utils import cleanup_phishing_urls

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,7 +1,5 @@
 import pytest
-import time
 from app import create_app, db, limiter
-from app.models import User
 from config import Config
 
 class TestConfig(Config):

--- a/tests/test_redirection.py
+++ b/tests/test_redirection.py
@@ -1,6 +1,4 @@
-import pytest
 from app.models import db, URL, Click
-from flask import session
 import datetime
 
 def test_basic_redirection(client, app):

--- a/tests/test_stats_access.py
+++ b/tests/test_stats_access.py
@@ -1,4 +1,3 @@
-import pytest
 from app.models import db, URL
 
 def test_stats_access_owner(client, app, test_user):


### PR DESCRIPTION
The unused import 'metrics' in `app/routes.py` was confirmed to be already removed. However, to fulfill the goal of cleaning up the namespace and improving readability, 9 other unused imports identified by the `ruff` linter in the `tests/` directory were removed. 

Changes:
- Removed unused `pytest` imports in multiple test files.
- Removed unused `os`, `time`, and `flask.url_for` imports in tests.
- Verified that all 92 tests pass.

---
*PR created automatically by Jules for task [15197082353727870717](https://jules.google.com/task/15197082353727870717) started by @arumes31*