### PR TITLE
[FIX] Unused Import `uuid`

### DIFF
--- a/tests/test_csv_injection.py
+++ b/tests/test_csv_injection.py
@@ -1,6 +1,5 @@
 import io
 import csv
-import pytest
 from app.models import db, URL
 
 def test_csv_export_sanitization(client, app, test_user):

--- a/tests/test_index_refactor.py
+++ b/tests/test_index_refactor.py
@@ -1,6 +1,4 @@
-import pytest
 from app.models import db, URL
-from flask import url_for
 import datetime
 
 def test_index_get(client):

--- a/tests/test_phishing_cleanup.py
+++ b/tests/test_phishing_cleanup.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from unittest.mock import patch, MagicMock
 from app.models import db, URL
 from app.utils import cleanup_phishing_urls

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,7 +1,5 @@
 import pytest
-import time
 from app import create_app, db, limiter
-from app.models import User
 from config import Config
 
 class TestConfig(Config):

--- a/tests/test_redirection.py
+++ b/tests/test_redirection.py
@@ -1,6 +1,4 @@
-import pytest
 from app.models import db, URL, Click
-from flask import session
 import datetime
 
 def test_basic_redirection(client, app):

--- a/tests/test_stats_access.py
+++ b/tests/test_stats_access.py
@@ -1,4 +1,3 @@
-import pytest
 from app.models import db, URL
 
 def test_stats_access_owner(client, app, test_user):


### PR DESCRIPTION
Removing unused imports cleans up the namespace and improves readability. Although `import uuid` was already absent from `app/models.py` in the current branch, a project-wide cleanup was performed to remove other unused imports (e.g., `pytest`, `os`, `flask.url_for`) identified by `ruff` in the `tests/` directory. All tests passed successfully.

---
*PR created automatically by Jules for task [1144977941160934380](https://jules.google.com/task/1144977941160934380) started by @arumes31*