### PR TITLE
[FIX] Unused Import `Limiter`

### DIFF
--- a/tests/test_csv_injection.py
+++ b/tests/test_csv_injection.py
@@ -1,6 +1,5 @@
 import io
 import csv
-import pytest
 from app.models import db, URL
 
 def test_csv_export_sanitization(client, app, test_user):

--- a/tests/test_index_refactor.py
+++ b/tests/test_index_refactor.py
@@ -1,6 +1,4 @@
-import pytest
 from app.models import db, URL
-from flask import url_for
 import datetime
 
 def test_index_get(client):

--- a/tests/test_phishing_cleanup.py
+++ b/tests/test_phishing_cleanup.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from unittest.mock import patch, MagicMock
 from app.models import db, URL
 from app.utils import cleanup_phishing_urls

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,7 +1,5 @@
 import pytest
-import time
 from app import create_app, db, limiter
-from app.models import User
 from config import Config
 
 class TestConfig(Config):

--- a/tests/test_redirection.py
+++ b/tests/test_redirection.py
@@ -1,6 +1,4 @@
-import pytest
 from app.models import db, URL, Click
-from flask import session
 import datetime
 
 def test_basic_redirection(client, app):

--- a/tests/test_stats_access.py
+++ b/tests/test_stats_access.py
@@ -1,4 +1,3 @@
-import pytest
 from app.models import db, URL
 
 def test_stats_access_owner(client, app, test_user):


### PR DESCRIPTION
This PR removes unused imports project-wide as identified by `ruff`. 

Specifically:
- It cleans up redundant imports in several test files (e.g., `pytest`, `os`, `time`, `flask.url_for`).
- It confirms that the `Limiter` and `metrics` imports in `app/routes.py` mentioned in the issue are already removed/absent.
- It ensures the codebase remains clean and readable without any functional impact.

All 92 tests passed successfully after the cleanup.

---
*PR created automatically by Jules for task [12222972279089658131](https://jules.google.com/task/12222972279089658131) started by @arumes31*