### PR TITLE
[FIX] Remove unused and redundant imports

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -484,7 +484,6 @@ def _record_click(url_entry, user_agent, client_ip):
     db.session.commit()
 
 def _get_time_range_config(range_type, now):
-    import datetime
     if range_type == '24h':
         cutoff = now - datetime.timedelta(hours=24)
         days = 1
@@ -525,7 +524,6 @@ def _anonymize_ip(ip):
     return 'xxxx'
 
 def _get_relative_time(ts, now):
-    import datetime
     ts_aware = ts.replace(tzinfo=datetime.timezone.utc) if ts.tzinfo is None else ts
     diff = now - ts_aware
     if diff.days > 0:

--- a/tests/test_csv_injection.py
+++ b/tests/test_csv_injection.py
@@ -1,6 +1,5 @@
 import io
 import csv
-import pytest
 from app.models import db, URL
 
 def test_csv_export_sanitization(client, app, test_user):

--- a/tests/test_index_refactor.py
+++ b/tests/test_index_refactor.py
@@ -1,6 +1,4 @@
-import pytest
 from app.models import db, URL
-from flask import url_for
 import datetime
 
 def test_index_get(client):

--- a/tests/test_phishing_cleanup.py
+++ b/tests/test_phishing_cleanup.py
@@ -1,5 +1,4 @@
 import pytest
-import os
 from unittest.mock import patch, MagicMock
 from app.models import db, URL
 from app.utils import cleanup_phishing_urls

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,7 +1,5 @@
 import pytest
-import time
 from app import create_app, db, limiter
-from app.models import User
 from config import Config
 
 class TestConfig(Config):

--- a/tests/test_redirection.py
+++ b/tests/test_redirection.py
@@ -1,6 +1,4 @@
-import pytest
 from app.models import db, URL, Click
-from flask import session
 import datetime
 
 def test_basic_redirection(client, app):

--- a/tests/test_stats_access.py
+++ b/tests/test_stats_access.py
@@ -1,4 +1,3 @@
-import pytest
 from app.models import db, URL
 
 def test_stats_access_owner(client, app, test_user):


### PR DESCRIPTION
This PR addresses the issue of unused and redundant imports in the codebase.
Specifically:
1. Verified that `import json` was already removed from `app/routes.py`.
2. Removed redundant `import datetime` statements within functions in `app/routes.py`, as it is already imported at the module level.
3. Cleaned up unused imports (such as `pytest`, `os`, `flask.session`, and `flask.url_for`) across the `tests/` directory to maintain a clean and readable codebase.
All tests passed and linting checks are clean.

---
*PR created automatically by Jules for task [6072399849979583075](https://jules.google.com/task/6072399849979583075) started by @arumes31*