### PR TITLE
fix(ci): restore Node 24 asset minification

### DIFF
--- a/.github/workflows/daily-security.yml
+++ b/.github/workflows/daily-security.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload gosec SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: gosec.sarif
           category: gosec
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build image
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -67,7 +67,7 @@ jobs:
 
           count=0
           while IFS= read -r -d '' file; do
-            output="${file}.minified"
+            output="$(mktemp --suffix=.js)"
             before="$(wc -c < "$file")"
 
             npx --yes "terser@${TERSER_VERSION}" "$file" \
@@ -82,6 +82,7 @@ jobs:
               exit 1
             fi
 
+            chmod --reference="$file" "$output"
             mv "$output" "$file"
             echo "Minified $file ($before -> $after bytes)"
             count=$((count + 1))
@@ -93,7 +94,7 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to the Container registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload gosec SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: gosec.sarif
           category: gosec
@@ -273,7 +273,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       # Build without pushing, so a broken Dockerfile fails the pull request
       # rather than the publish job after merge.

--- a/internal/web/handlers_pages_test.go
+++ b/internal/web/handlers_pages_test.go
@@ -1,0 +1,28 @@
+package web
+
+import "testing"
+
+func TestIsSafeRedirect(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		want   bool
+	}{
+		{name: "root", target: "/", want: true},
+		{name: "same-site path", target: "/dashboard?tab=links#recent", want: true},
+		{name: "empty", target: "", want: false},
+		{name: "relative path", target: "dashboard", want: false},
+		{name: "absolute URL", target: "https://attacker.example/", want: false},
+		{name: "protocol-relative URL", target: "//attacker.example/", want: false},
+		{name: "backslash authority", target: `/\attacker.example/`, want: false},
+		{name: "control character", target: "/\nattacker.example/", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isSafeRedirect(tt.target); got != tt.want {
+				t.Errorf("isSafeRedirect(%q) = %t, want %t", tt.target, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes the publish failure under Node 24 by giving the temporary minified asset a .js suffix so node --check recognizes it, while preserving the original file mode before replacement. Includes the verified action-pin updates from #258 and adds regression coverage for the existing same-site redirect allowlist. Validation: exact three-file Terser workflow rehearsal, go test -race ./..., go vet ./..., go build ./..., gosec v2.28.0, and govulncheck v1.7.0 (zero reachable vulnerabilities).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved asset minification during automated builds while preserving original file permissions.

- **Security**
  - Updated security scanning and container build tooling to newer releases.
  - Expanded validation coverage for safe redirects, including absolute URLs, protocol-relative URLs, backslashes, and control characters.

- **Chores**
  - Continued pinning automated workflow actions to exact revisions for reproducible and secure builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->