### PR TITLE
fix(config): use writable blocklist path

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,12 +25,12 @@ jobs:
         persist-credentials: false
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
       with:
         languages: go, javascript-typescript
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/daily-security.yml
+++ b/.github/workflows/daily-security.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload gosec SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: gosec.sarif
           category: gosec

--- a/.github/workflows/security-analysis.yml
+++ b/.github/workflows/security-analysis.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Upload gosec SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: gosec.sarif
           category: gosec

--- a/example.env
+++ b/example.env
@@ -36,7 +36,7 @@ PHISHING_CHECK_INTERVAL=24
 ENABLE_AUTO_REMOVE_PHISHING=false
 PHISHING_REMOVE_INTERVAL=24
 PHISHING_LIST_URLS=https://raw.githubusercontent.com/mitchellkrogza/Phishing.Database/master/phishing-domains-ACTIVE.txt
-BLOCKED_DOMAINS_PATH=/app/blocked_domains.txt
+BLOCKED_DOMAINS_PATH=/app/data/blocked_domains.txt
 
 # GeoIP (MaxMind)
 MAXMIND_ACCOUNT_ID=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,7 +151,7 @@ func Load() (*Config, error) {
 
 		PhishingListURLs: envList("PHISHING_LIST_URLS",
 			"https://raw.githubusercontent.com/mitchellkrogza/Phishing.Database/master/phishing-domains-ACTIVE.txt"),
-		BlockedDomainsPath:     env("BLOCKED_DOMAINS_PATH", filepath.Join(baseDir, "blocked_domains.txt")),
+		BlockedDomainsPath:     env("BLOCKED_DOMAINS_PATH", filepath.Join(baseDir, "data", "blocked_domains.txt")),
 		PhishingCheckInterval:  envInt("PHISHING_CHECK_INTERVAL", 24),
 		EnablePhishingCheck:    envBool("ENABLE_PHISHING_CHECK", true),
 		EnableAutoRemovePhish:  envBool("ENABLE_AUTO_REMOVE_PHISHING", false),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -129,6 +131,28 @@ func TestDefaultsMatchPreviousDeployment(t *testing.T) {
 
 	if !strings.HasPrefix(cfg.DatabaseURL, "sqlite:///") {
 		t.Errorf("DatabaseURL = %q, want the SQLite fallback", cfg.DatabaseURL)
+	}
+	baseDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if want := filepath.Join(baseDir, "data", "blocked_domains.txt"); cfg.BlockedDomainsPath != want {
+		t.Errorf("BlockedDomainsPath = %q, want %q", cfg.BlockedDomainsPath, want)
+	}
+}
+
+func TestBlockedDomainsPathOverrideIsPreserved(t *testing.T) {
+	clearEnv(t)
+	t.Setenv("REDRX_DEBUG", "true")
+	t.Setenv("SECRET_KEY", "a-key")
+	t.Setenv("BLOCKED_DOMAINS_PATH", "/srv/redrx/blocklist.txt")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.BlockedDomainsPath != "/srv/redrx/blocklist.txt" {
+		t.Errorf("BlockedDomainsPath = %q, want the explicit override", cfg.BlockedDomainsPath)
 	}
 }
 


### PR DESCRIPTION
Fixes the runtime permission failure when the image relies on the application default: the phishing refresh was writing beside the binary at /app/blocked_domains.txt, but the non-root image reserves /app/data for writable state. The default and example.env now use /app/data/blocked_domains.txt, while explicit custom paths remain supported and covered by tests. Also incorporates the exact CodeQL v4.37.9 pins from #262 after verifying the official tag resolves to signed commit cdf488f595d80d6e07e03d4674febd5ab45fa938. Validation: focused regression test, go test -race ./..., go vet ./..., go build ./..., gofmt, git diff --check, plus full GitHub CI.